### PR TITLE
Align executor timeout on shutdown timeout

### DIFF
--- a/helm/antu/templates/configmap.yaml
+++ b/helm/antu/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
     camel.main.stream-caching-enabled=false
     camel.main.stream-caching-spool-enabled=true
     # the Camel shutdown timeout must be shorter than the Kubernetes terminationGracePeriod
-    antu.shutdown.timeout=75
+    antu.shutdown.timeout=175
     antu.camel.redelivery.max=0
 
     # Organisation register

--- a/helm/antu/templates/deployment.yaml
+++ b/helm/antu/templates/deployment.yaml
@@ -135,7 +135,7 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 1000
-      terminationGracePeriodSeconds: 80
+      terminationGracePeriodSeconds: 180
       volumes:
         - name: application-config
           configMap:

--- a/src/main/java/no/entur/antu/App.java
+++ b/src/main/java/no/entur/antu/App.java
@@ -50,6 +50,9 @@ public class App extends RouteBuilder {
   @Override
   public void configure() {
     getContext().getShutdownStrategy().setTimeout(shutdownTimeout);
+    getContext()
+      .getExecutorServiceManager()
+      .setShutdownAwaitTermination(shutdownTimeout * 1000);
     getContext().setUseMDCLogging(true);
     getContext().setUseBreadcrumb(true);
     getContext().setMessageHistory(true);


### PR DESCRIPTION
Ensure that the thread pool associated with the job queue is not shut down too early, thus giving enough time to complete the current validation before stopping the process.