### PR TITLE
Add support for validation state

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <entur.google.pubsub.emulator.download.skip>true</entur.google.pubsub.emulator.download.skip>
         <camel.version>4.10.4</camel.version>
         <entur.helpers.version>5.10</entur.helpers.version>
-        <netex-validator-java.version>10.0.3</netex-validator-java.version>
+        <netex-validator-java.version>10.1.0-SNAPSHOT</netex-validator-java.version>
         <netex-parser-java.version>3.1.47</netex-parser-java.version>
         <jts-core.version>1.20.0</jts-core.version>
         <commons-io.version>2.11.0</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <entur.google.pubsub.emulator.download.skip>true</entur.google.pubsub.emulator.download.skip>
         <camel.version>4.10.4</camel.version>
         <entur.helpers.version>5.10</entur.helpers.version>
-        <netex-validator-java.version>10.1.0-SNAPSHOT</netex-validator-java.version>
+        <netex-validator-java.version>10.1.0</netex-validator-java.version>
         <netex-parser-java.version>3.1.47</netex-parser-java.version>
         <jts-core.version>1.20.0</jts-core.version>
         <commons-io.version>2.11.0</commons-io.version>

--- a/src/main/java/no/entur/antu/config/ValidatorConfig.java
+++ b/src/main/java/no/entur/antu/config/ValidatorConfig.java
@@ -21,6 +21,7 @@ import static no.entur.antu.validation.ValidationProfile.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import no.entur.antu.routes.validation.ValidationStateRepository;
 import no.entur.antu.validation.NetexValidationProfile;
 import no.entur.antu.validation.validator.id.NetexIdValidator;
 import no.entur.antu.validation.validator.id.ReferenceToNsrValidator;
@@ -157,7 +158,8 @@ public class ValidatorConfig {
     ) boolean skipSchemaValidation,
     @Value(
       "${antu.netex.validation.validators.skip:false}"
-    ) boolean skipNetexValidators
+    ) boolean skipNetexValidators,
+    ValidationStateRepository validationStateRepository
   ) {
     return new NetexValidationProfile(
       Map.of(
@@ -176,6 +178,7 @@ public class ValidatorConfig {
         STOP,
         stopDataValidatorsRunner
       ),
+      validationStateRepository,
       skipSchemaValidation,
       skipNetexValidators
     );

--- a/src/main/java/no/entur/antu/config/cache/CacheConfig.java
+++ b/src/main/java/no/entur/antu/config/cache/CacheConfig.java
@@ -47,6 +47,8 @@ public class CacheConfig {
   public static final String ORGANISATION_ALIAS_CACHE =
     "organisationAliasCache";
 
+  public static final String VALIDATION_STATE_CACHE = "validationProgressCache";
+
   private static final Kryo5Codec DEFAULT_CODEC = new Kryo5Codec();
 
   /**
@@ -156,6 +158,17 @@ public class CacheConfig {
   @Bean(name = ORGANISATION_ALIAS_CACHE)
   public Set<String> organisationAliasCache(RedissonClient redissonClient) {
     return redissonClient.getSet(ORGANISATION_ALIAS_CACHE);
+  }
+
+  @Bean(name = VALIDATION_STATE_CACHE)
+  public Map<String, no.entur.antu.config.cache.ValidationState> validationStateCache(
+    RedissonClient redissonClient
+  ) {
+    return getOrCreateReportScopedCache(
+      redissonClient,
+      VALIDATION_STATE_CACHE,
+      DEFAULT_CODEC
+    );
   }
 
   /**

--- a/src/main/java/no/entur/antu/config/cache/ValidationState.java
+++ b/src/main/java/no/entur/antu/config/cache/ValidationState.java
@@ -1,0 +1,20 @@
+package no.entur.antu.config.cache;
+
+/**
+ * The state of an in-progress validation.
+ */
+public class ValidationState {
+
+  private boolean hasErrorInCommonFile;
+
+  public void setHasErrorInCommonFile(boolean hasErrorInCommonFile) {
+    this.hasErrorInCommonFile = hasErrorInCommonFile;
+  }
+
+  /**
+   * Return true if at least one error or critical validation issue was reported in a common file.
+   */
+  public boolean hasErrorInCommonFile() {
+    return hasErrorInCommonFile;
+  }
+}

--- a/src/main/java/no/entur/antu/config/cache/ValidationStateConfig.java
+++ b/src/main/java/no/entur/antu/config/cache/ValidationStateConfig.java
@@ -1,0 +1,23 @@
+package no.entur.antu.config.cache;
+
+import static no.entur.antu.config.cache.CacheConfig.*;
+
+import java.util.Map;
+import no.entur.antu.routes.validation.DefaultValidationStateRepository;
+import no.entur.antu.routes.validation.ValidationStateRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ValidationStateConfig {
+
+  @Bean
+  public ValidationStateRepository validationStateRepository(
+    @Qualifier(
+      VALIDATION_STATE_CACHE
+    ) Map<String, ValidationState> validationStates
+  ) {
+    return new DefaultValidationStateRepository(validationStates);
+  }
+}

--- a/src/main/java/no/entur/antu/routes/validation/AggregateValidationReportsRouteBuilder.java
+++ b/src/main/java/no/entur/antu/routes/validation/AggregateValidationReportsRouteBuilder.java
@@ -80,11 +80,14 @@ public class AggregateValidationReportsRouteBuilder extends BaseRouteBuilder {
 
   private static final String PROP_STOP_WATCH = "PROP_STOP_WATCH";
   private final AntuPrometheusMetricsService antuPrometheusMetricsService;
+  private final ValidationStateRepository validationStateRepository;
 
   public AggregateValidationReportsRouteBuilder(
-    AntuPrometheusMetricsService antuPrometheusMetricsService
+    AntuPrometheusMetricsService antuPrometheusMetricsService,
+    ValidationStateRepository validationStateRepository
   ) {
     this.antuPrometheusMetricsService = antuPrometheusMetricsService;
+    this.validationStateRepository = validationStateRepository;
   }
 
   @Override
@@ -162,7 +165,11 @@ public class AggregateValidationReportsRouteBuilder extends BaseRouteBuilder {
       .process(exchange ->
         exchange.setProperty(
           PROP_NETEX_VALIDATION_CALLBACK,
-          new AntuNetexValidationProgressCallback(this, exchange)
+          new AntuNetexValidationProgressCallback(
+            this,
+            exchange,
+            validationStateRepository
+          )
         )
       )
       .bean(
@@ -337,6 +344,10 @@ public class AggregateValidationReportsRouteBuilder extends BaseRouteBuilder {
       )
       .bean(
         "netexDataRepository",
+        "cleanUp(${header." + VALIDATION_REPORT_ID_HEADER + "})"
+      )
+      .bean(
+        "validationStateRepository",
         "cleanUp(${header." + VALIDATION_REPORT_ID_HEADER + "})"
       )
       .log(LoggingLevel.INFO, correlation() + "Cleaned up cache")

--- a/src/main/java/no/entur/antu/routes/validation/DefaultValidationStateRepository.java
+++ b/src/main/java/no/entur/antu/routes/validation/DefaultValidationStateRepository.java
@@ -1,0 +1,42 @@
+package no.entur.antu.routes.validation;
+
+import java.util.Map;
+import no.entur.antu.config.cache.ValidationState;
+
+public class DefaultValidationStateRepository
+  implements ValidationStateRepository {
+
+  private final Map<String, ValidationState> validationStates;
+
+  public DefaultValidationStateRepository(
+    Map<String, ValidationState> validationStates
+  ) {
+    this.validationStates = validationStates;
+  }
+
+  @Override
+  public ValidationState getValidationState(String validationReportId) {
+    return validationStates.get(validationReportId);
+  }
+
+  @Override
+  public void updateValidationState(
+    String validationReportId,
+    ValidationState validationState
+  ) {
+    validationStates.put(validationReportId, validationState);
+  }
+
+  @Override
+  public void createValidationStateIfMissing(
+    String validationReportId,
+    ValidationState validationState
+  ) {
+    validationStates.putIfAbsent(validationReportId, validationState);
+  }
+
+  @Override
+  public void cleanUp(String validationReportId) {
+    validationStates.remove(validationReportId);
+  }
+}

--- a/src/main/java/no/entur/antu/routes/validation/ValidateFilesRouteBuilder.java
+++ b/src/main/java/no/entur/antu/routes/validation/ValidateFilesRouteBuilder.java
@@ -53,6 +53,13 @@ public class ValidateFilesRouteBuilder extends BaseRouteBuilder {
   private static final String PROP_STOP_WATCH = "PROP_STOP_WATCH";
   private static final String PROP_NETEX_VALIDATION_CALLBACK =
     "PROP_NETEX_VALIDATION_CALLBACK";
+  private ValidationStateRepository validationStateRepository;
+
+  public ValidateFilesRouteBuilder(
+    ValidationStateRepository validationStateRepository
+  ) {
+    this.validationStateRepository = validationStateRepository;
+  }
 
   @Override
   public void configure() throws Exception {
@@ -136,7 +143,11 @@ public class ValidateFilesRouteBuilder extends BaseRouteBuilder {
       .process(exchange ->
         exchange.setProperty(
           PROP_NETEX_VALIDATION_CALLBACK,
-          new AntuNetexValidationProgressCallback(this, exchange)
+          new AntuNetexValidationProgressCallback(
+            this,
+            exchange,
+            validationStateRepository
+          )
         )
       )
       .bean(

--- a/src/main/java/no/entur/antu/routes/validation/ValidationStateRepository.java
+++ b/src/main/java/no/entur/antu/routes/validation/ValidationStateRepository.java
@@ -1,0 +1,26 @@
+package no.entur.antu.routes.validation;
+
+import no.entur.antu.config.cache.ValidationState;
+
+/**
+ * Store the current state of an in-progress validation.
+ *
+ */
+public interface ValidationStateRepository {
+  ValidationState getValidationState(String validationReportId);
+
+  void updateValidationState(
+    String validationReportId,
+    ValidationState validationState
+  );
+
+  void createValidationStateIfMissing(
+    String validationReportId,
+    ValidationState validationState
+  );
+
+  /**
+   * Clean up the NeTEx data repository for the given validation report.
+   */
+  void cleanUp(String validationReportId);
+}

--- a/src/main/java/no/entur/antu/validation/AntuNetexValidationProgressCallback.java
+++ b/src/main/java/no/entur/antu/validation/AntuNetexValidationProgressCallback.java
@@ -1,11 +1,23 @@
 package no.entur.antu.validation;
 
+import no.entur.antu.config.cache.ValidationState;
 import no.entur.antu.routes.BaseRouteBuilder;
+import no.entur.antu.routes.validation.ValidationStateRepository;
 import org.apache.camel.Exchange;
 import org.entur.netex.validation.validator.NetexValidationProgressCallBack;
+import org.entur.netex.validation.validator.ValidationCompleteEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Callback that tracks progress of an in-progress validation.
+ * The callback serves 2 purposes:
+ * <ul>
+ *     <li>Extending the Google PubSub ACK deadline when a validator is reporting progress,
+ *     to prevent PubSub timeout and redelivery</li>
+ *     <li>Updating the shared ValidationState with the output of a validator</li>
+ * </ul>
+ */
 public class AntuNetexValidationProgressCallback
   implements NetexValidationProgressCallBack {
 
@@ -15,18 +27,42 @@ public class AntuNetexValidationProgressCallback
 
   private final BaseRouteBuilder baseRouteBuilder;
   private final Exchange exchange;
+  private final ValidationStateRepository validationStateRepository;
 
   public AntuNetexValidationProgressCallback(
     BaseRouteBuilder baseRouteBuilder,
-    Exchange exchange
+    Exchange exchange,
+    ValidationStateRepository validationStateRepository
   ) {
     this.baseRouteBuilder = baseRouteBuilder;
     this.exchange = exchange;
+    this.validationStateRepository = validationStateRepository;
   }
 
+  /**
+   * Extends the PubSub ACK deadline to prevent PubSub redelivery.
+   */
   @Override
   public void notifyProgress(String message) {
     LOGGER.debug("Netex Validation progress: {}", message);
     baseRouteBuilder.extendAckDeadline(exchange);
+  }
+
+  /**
+   * Update the validation state with the result of a validator.
+   */
+  @Override
+  public void notifyValidationComplete(ValidationCompleteEvent event) {
+    if (event.hasError() && event.validationContext().isCommonFile()) {
+      ValidationState validationState =
+        validationStateRepository.getValidationState(
+          event.validationReportId()
+        );
+      validationState.setHasErrorInCommonFile(true);
+      validationStateRepository.updateValidationState(
+        event.validationReportId(),
+        validationState
+      );
+    }
   }
 }

--- a/src/main/java/no/entur/antu/validation/NetexValidationProfile.java
+++ b/src/main/java/no/entur/antu/validation/NetexValidationProfile.java
@@ -65,20 +65,19 @@ public class NetexValidationProfile {
       validationProfile
     );
 
-    ValidationState validationState =
-      validationStateRepository.getValidationState(validationReportId);
-    boolean validationAlreadyComplete = false;
-    boolean hasErrorInCommonFile = false;
-    if (validationState == null) {
+    boolean validationAlreadyComplete = validationAlreadyComplete(
+      validationReportId
+    );
+    if (validationAlreadyComplete) {
       LOGGER.info("The validation is already complete, ignoring");
-      validationAlreadyComplete = true;
-    } else {
-      hasErrorInCommonFile = validationState.hasErrorInCommonFile();
-      if (hasErrorInCommonFile) {
-        LOGGER.info(
-          "The validation failed in common file, ignoring NeTEx validators"
-        );
-      }
+    }
+    boolean hasErrorInCommonFile = validationHasErrorInCommonFile(
+      validationReportId
+    );
+    if (hasErrorInCommonFile) {
+      LOGGER.info(
+        "The validation failed in common file, ignoring NeTEx validators"
+      );
     }
     return netexValidatorsRunner.validate(
       codespace,
@@ -134,5 +133,21 @@ public class NetexValidationProfile {
       );
     }
     return netexValidatorsRunner;
+  }
+
+  private ValidationState getValidationState(String validationReportId) {
+    return validationStateRepository.getValidationState(validationReportId);
+  }
+
+  private boolean validationAlreadyComplete(String validationReportId) {
+    return getValidationState(validationReportId) == null;
+  }
+
+  private boolean validationHasErrorInCommonFile(String validationReportId) {
+    ValidationState validationState = getValidationState(validationReportId);
+    if (validationState != null) {
+      return validationState.hasErrorInCommonFile();
+    }
+    return false;
   }
 }

--- a/src/test/http/antu.pubsub.http
+++ b/src/test/http/antu.pubsub.http
@@ -64,3 +64,72 @@ Content-Type: application/json
   ]
 }
 
+
+###
+
+POST http://localhost:8085/v1/projects/test/topics/AntuNetexValidationQueue:publish
+Content-Type: application/json
+
+{
+  "messages": [
+    {
+      "attributes": {
+        "EnturValidationClient": "Marduk",
+        "EnturValidationCorrelationId": "14f2ba67-ce75-4be2-8052-6a0938069bc1",
+        "EnturValidationDatasetFileHandle": "inbound/received/atb/ATB_Export_20250513163359-2025-05-13T16_33_59_434.zip",
+        "EnturValidationImportType": "ImportType_netex_flex",
+        "EnturValidationProfile": "TimetableFlexibleTransport",
+        "EnturValidationStage": "EnturValidationStageFlexPostValidation",
+        "EnturDatasetReferential": "atb"
+      },
+      "data": ""
+    }
+  ]
+}
+
+
+###
+
+## validating a flex file with the wrong profile
+POST http://localhost:8085/v1/projects/test/topics/AntuNetexValidationQueue:publish
+Content-Type: application/json
+
+{
+"messages": [
+{
+"attributes": {
+"EnturValidationClient": "Marduk",
+"EnturValidationCorrelationId": "14f2ba67-ce75-4be2-8052-6a0938069bc1",
+"EnturValidationDatasetFileHandle": "inbound/received/atb/ATB_Export_20250513163359-2025-05-13T16_33_59_434.zip",
+"EnturValidationImportType": "ImportType_netex_flex",
+"EnturValidationProfile": "Timetable",
+"EnturValidationStage": "EnturValidationStagePrevalidation",
+"EnturDatasetReferential": "atb"
+},
+"data": ""
+}
+]
+}
+
+###
+
+## validating a flex file with the wrong profile
+POST http://localhost:8085/v1/projects/test/topics/AntuNetexValidationQueue:publish
+Content-Type: application/json
+
+{
+  "messages": [
+    {
+      "attributes": {
+        "EnturValidationClient": "Marduk",
+        "EnturValidationCorrelationId": "14f2ba67-ce75-4be2-8052-6a0938069bc1",
+        "EnturValidationDatasetFileHandle": "inbound/received/atb/ATB_Export_20250512102616-2025-05-12T10_26_16_854.zip",
+        "EnturValidationImportType": "ImportType_netex_flex",
+        "EnturValidationProfile": "Timetable",
+        "EnturValidationStage": "EnturValidationStagePrevalidation",
+        "EnturDatasetReferential": "atb"
+      },
+      "data": ""
+    }
+  ]
+}

--- a/src/test/java/no/entur/antu/config/TestConfig.java
+++ b/src/test/java/no/entur/antu/config/TestConfig.java
@@ -1,10 +1,8 @@
 package no.entur.antu.config;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import no.entur.antu.netexdata.NetexDataRepositoryLoader;
-import no.entur.antu.organisation.SimpleOrganisationAliasRepository;
 import no.entur.antu.stop.StopPlaceRepositoryLoader;
 import no.entur.antu.validation.validator.organisation.OrganisationAliasRepository;
 import org.entur.netex.index.api.NetexEntitiesIndex;
@@ -32,7 +30,7 @@ public class TestConfig {
   @Bean
   @Primary
   public OrganisationAliasRepository organisationAliasRepository() {
-    return new SimpleOrganisationAliasRepository(new HashSet<>());
+    return new TestOrganisationAliasRepository();
   }
 
   @Bean(name = "stopPlaceRepository")
@@ -135,12 +133,12 @@ public class TestConfig {
 
     @Override
     public boolean hasStopPlaceId(StopPlaceId stopPlaceId) {
-      return false;
+      return true;
     }
 
     @Override
     public boolean hasQuayId(QuayId quayId) {
-      return false;
+      return true;
     }
 
     @Override
@@ -165,5 +163,22 @@ public class TestConfig {
 
     @Override
     public void refreshCache() {}
+  }
+
+  private static class TestOrganisationAliasRepository
+    implements OrganisationAliasRepository {
+
+    @Override
+    public boolean hasOrganisationWithAlias(String organisationId) {
+      return true;
+    }
+
+    @Override
+    public void refreshCache() {}
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
Add a shared object `ValidationState` that represents the state of an in-progress validation. This can be used to control the validation workflow, for example when downstream validators must be skipped because an upstream validator failed.
The implementation leverages the event-publisher framework provided by  `NetexValidationProgressCallBack` to retrieve information of the result of a validator execution and store it in the `ValidationState`.