### PR TITLE
Remove PubSub emulator configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     </scm>
     <properties>
         <java.version>17</java.version>
-        <entur.google.pubsub.emulator.download.skip>true</entur.google.pubsub.emulator.download.skip>
         <camel.version>4.10.5</camel.version>
         <entur.helpers.version>5.14</entur.helpers.version>
         <netex-validator-java.version>10.3.0</netex-validator-java.version>


### PR DESCRIPTION
Remove the configuration for downloading the PubSub emulator in unit tests.
This configuration is not needed since the default value set in the superpom is "true".
Support for downloading the PubSub emulator is deprecated for removal and being replaced by testcontainer.