### PR TITLE
Ignore message redelivery after validation is complete

### DIFF
--- a/src/main/java/no/entur/antu/routes/validation/ValidationStateRepository.java
+++ b/src/main/java/no/entur/antu/routes/validation/ValidationStateRepository.java
@@ -9,6 +9,10 @@ import no.entur.antu.config.cache.ValidationState;
 public interface ValidationStateRepository {
   ValidationState getValidationState(String validationReportId);
 
+  default boolean hasValidationState(String validationReportId) {
+    return getValidationState(validationReportId) != null;
+  }
+
   void updateValidationState(
     String validationReportId,
     ValidationState validationState

--- a/src/test/java/no/entur/antu/routes/validation/InitValidationRouteBuilderTest.java
+++ b/src/test/java/no/entur/antu/routes/validation/InitValidationRouteBuilderTest.java
@@ -492,7 +492,7 @@ class InitValidationRouteBuilderTest
     );
 
     notifyStatus.expectedMessageCount(2);
-    notifyStatus.setResultWaitTime(300000);
+    notifyStatus.setResultWaitTime(60_000);
 
     InputStream testDatasetAsStream = getClass()
       .getResourceAsStream('/' + TEST_DATASET_NO_DUPLICATED_ID);
@@ -616,7 +616,7 @@ class InitValidationRouteBuilderTest
     );
 
     notifyStatus.expectedMessageCount(2);
-    notifyStatus.setResultWaitTime(300000);
+    notifyStatus.setResultWaitTime(60_000);
 
     InputStream testDatasetAsStream = getClass()
       .getResourceAsStream('/' + TEST_DATASET_DUPLICATED_ID);

--- a/src/test/java/no/entur/antu/routes/validation/ProcessJobRouteBuilderTest.java
+++ b/src/test/java/no/entur/antu/routes/validation/ProcessJobRouteBuilderTest.java
@@ -1,0 +1,151 @@
+/*
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *  *
+ *
+ */
+
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.entur.antu.routes.validation;
+
+import static no.entur.antu.Constants.*;
+
+import java.util.Map;
+import no.entur.antu.AntuRouteBuilderIntegrationTestBase;
+import no.entur.antu.TestApp;
+import no.entur.antu.config.cache.ValidationState;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+  webEnvironment = SpringBootTest.WebEnvironment.NONE,
+  classes = TestApp.class,
+  properties = { "antu.netex.validation.entries.max=1" }
+)
+class ProcessJobRouteBuilderTest extends AntuRouteBuilderIntegrationTestBase {
+
+  private static final String TEST_REPORT_ID = "reportId";
+  private static final String OTHER_TEST_REPORT_ID = "other_reportId";
+
+  @Autowired
+  ValidationStateRepository validationStateRepository;
+
+  @Produce("direct:processJob")
+  protected ProducerTemplate processJob;
+
+  @EndpointInject("mock:notifyStatus")
+  protected MockEndpoint notifyStatus;
+
+  @EndpointInject("mock:validateNetex")
+  protected MockEndpoint validateNetex;
+
+  @EndpointInject("mock:refreshStopCache")
+  protected MockEndpoint refreshStopCache;
+
+  @Test
+  void testIgnoreValidationJobAfterCompletion() throws Exception {
+    AdviceWith.adviceWith(
+      context,
+      "process-job",
+      a ->
+        a
+          .interceptSendToEndpoint("direct:validateNetex")
+          .skipSendToOriginalEndpoint()
+          .to("mock:validateNetex")
+    );
+
+    validateNetex.expectedMessageCount(0);
+    context.start();
+    Map<String, Object> headers = Map.of(
+      VALIDATION_REPORT_ID_HEADER,
+      OTHER_TEST_REPORT_ID,
+      JOB_TYPE,
+      JOB_TYPE_VALIDATE
+    );
+    processJob.sendBodyAndHeaders(" ", headers);
+    validateNetex.assertIsSatisfied();
+  }
+
+  @Test
+  void testAcceptValidationJobBeforeCompletion() throws Exception {
+    AdviceWith.adviceWith(
+      context,
+      "process-job",
+      a ->
+        a
+          .interceptSendToEndpoint("direct:validateNetex")
+          .skipSendToOriginalEndpoint()
+          .to("mock:validateNetex")
+    );
+
+    validateNetex.expectedMessageCount(1);
+
+    context.start();
+
+    validationStateRepository.createValidationStateIfMissing(
+      TEST_REPORT_ID,
+      new ValidationState()
+    );
+
+    Map<String, Object> headers = Map.of(
+      VALIDATION_REPORT_ID_HEADER,
+      TEST_REPORT_ID,
+      JOB_TYPE,
+      JOB_TYPE_VALIDATE
+    );
+    processJob.sendBodyAndHeaders(" ", headers);
+    validateNetex.assertIsSatisfied();
+  }
+
+  @Test
+  void testAcceptOtherTypesOfJob() throws Exception {
+    AdviceWith.adviceWith(
+      context,
+      "process-job",
+      a ->
+        a
+          .interceptSendToEndpoint("direct:refreshStopCache")
+          .skipSendToOriginalEndpoint()
+          .to("mock:refreshStopCache")
+    );
+
+    refreshStopCache.expectedMessageCount(1);
+
+    context.start();
+    Map<String, Object> headers = Map.of(JOB_TYPE, JOB_TYPE_REFRESH_STOP_CACHE);
+    processJob.sendBodyAndHeaders(" ", headers);
+    refreshStopCache.assertIsSatisfied();
+  }
+}

--- a/src/test/java/no/entur/antu/routes/validation/SwedenDatasetValidationTest.java
+++ b/src/test/java/no/entur/antu/routes/validation/SwedenDatasetValidationTest.java
@@ -121,7 +121,7 @@ class SwedenDatasetValidationTest extends AntuRouteBuilderIntegrationTestBase {
     );
 
     notifyStatus.expectedMessageCount(2);
-    notifyStatus.setResultWaitTime(150000);
+    notifyStatus.setResultWaitTime(120_000);
 
     InputStream testDatasetAsStream = getClass()
       .getResourceAsStream('/' + TEST_DATASET_SWEDEN_VALIDATION_FILE_NAME);


### PR DESCRIPTION
This PR ensures that duplicated PubSub messages that enter the job queue after the validation is complete are ignored.
In the current implementation, these messages are also ignored, but only after checking that the caches are empty, which produces noise in the log messages (warning messages, stack traces, ...).
Checking if the validation is complete is done by retrieving the ValidationState for a given validation report id.
If the validation state is not present anymore in the repository, it means the validation is complete.
