### PR TITLE
Reduce default ACK extension deadline.

### DIFF
--- a/helm/antu/templates/configmap.yaml
+++ b/helm/antu/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
     # the Camel shutdown timeout must be shorter than the Kubernetes terminationGracePeriod
     antu.shutdown.timeout=175
     antu.camel.redelivery.max=0
-    
+
     # Agreement registry
     antu.organisation.refresh.interval=trigger.repeatInterval=1800000&trigger.repeatCount=-1&stateful=true
     antu.agreement.registry.url={{ .Values.agreementRegistryUrl }}
@@ -45,8 +45,6 @@ data:
     antu.pubsub.project.id={{ .Values.gcp.pubsubProjectId }}
     spring.cloud.gcp.project-id=${antu.pubsub.project.id}
     camel.component.google-pubsub.synchronous-pull-retryable-codes=DEADLINE_EXCEEDED
-    # extend the ACK deadline to 200s to be able to validate XML schema on large files
-    antu.camel.pubsub.deadline.extension=200
 
     #OAuth2 Resource Server
     antu.oauth2.resourceserver.auth0.ror.claim.namespace=https://ror.entur.io/

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -91,7 +91,7 @@ resource "google_pubsub_subscription" "AntuJobQueue" {
   topic = google_pubsub_topic.AntuJobQueue.name
   project = var.gcp_resources_project
   labels = var.labels
-  ack_deadline_seconds = 200
+  ack_deadline_seconds = 60
   message_retention_duration = "3600s"
   retry_policy {
     minimum_backoff = "10s"


### PR DESCRIPTION
Reduce the default deadline to 60s. The deadline will be extended during validation if needed (see no.entur.antu.routes.BaseRouteBuilder#extendAckDeadline)