### PR TITLE
Add authentication test

### DIFF
--- a/src/test/java/no/entur/antu/routes/rest/RestValidationReportRouteBuilderIntegrationTest.java
+++ b/src/test/java/no/entur/antu/routes/rest/RestValidationReportRouteBuilderIntegrationTest.java
@@ -21,8 +21,6 @@ import static no.entur.antu.Constants.VALIDATION_REPORT_PREFIX;
 import static no.entur.antu.Constants.VALIDATION_REPORT_SUFFIX;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.springframework.security.config.Customizer.withDefaults;
 
 import com.nimbusds.jose.JWSAlgorithm;
@@ -40,10 +38,10 @@ import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.junit.jupiter.api.Test;
+import org.rutebanken.helper.organisation.authorization.AuthorizationService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -148,10 +146,12 @@ class RestValidationReportRouteBuilderIntegrationTest
         .audience(Set.of("test-audience"))
         .build();
     }
-  }
 
-  @MockBean
-  private AntuAuthorizationService antuAuthorizationService;
+    @Bean
+    public AuthorizationService<String> testAuthorizationService() {
+      return new TestRutebankenAuthorizationService();
+    }
+  }
 
   @Produce(
     "http:localhost:{{server.port}}/services/validation-report/" +
@@ -163,11 +163,6 @@ class RestValidationReportRouteBuilderIntegrationTest
 
   @Test
   void getValidationReport() throws Exception {
-    // Mock authorization
-    doNothing()
-      .when(antuAuthorizationService)
-      .verifyRouteDataEditorPrivileges(anyString());
-
     // Prepare test data - create a mock validation report JSON
     String testReportJson =
       "{\"validationReportId\":\"" +

--- a/src/test/java/no/entur/antu/routes/rest/TestAuthorizationService.java
+++ b/src/test/java/no/entur/antu/routes/rest/TestAuthorizationService.java
@@ -1,0 +1,59 @@
+package no.entur.antu.routes.rest;
+
+import org.rutebanken.helper.organisation.authorization.AuthorizationService;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Test implementation of the rutebanken authorization service that checks that the user is authenticated.
+ */
+class TestRutebankenAuthorizationService
+  implements AuthorizationService<String> {
+
+  @Override
+  public boolean isRouteDataAdmin() {
+    checkSecurityContext();
+    return true;
+  }
+
+  @Override
+  public boolean isOrganisationAdmin() {
+    checkSecurityContext();
+    return true;
+  }
+
+  @Override
+  public boolean canViewAllOrganisationData() {
+    checkSecurityContext();
+    return true;
+  }
+
+  @Override
+  public boolean canViewRouteData(String providerId) {
+    checkSecurityContext();
+    return true;
+  }
+
+  @Override
+  public boolean canEditRouteData(String providerId) {
+    checkSecurityContext();
+    return true;
+  }
+
+  @Override
+  public boolean canViewBlockData(String providerId) {
+    checkSecurityContext();
+    return true;
+  }
+
+  @Override
+  public boolean canViewRoleAssignments() {
+    checkSecurityContext();
+    return true;
+  }
+
+  private void checkSecurityContext() {
+    if (SecurityContextHolder.getContext().getAuthentication() == null) {
+      throw new IllegalStateException("No security context");
+    }
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -71,9 +71,6 @@ spring.security.oauth2.client.registration.antu.client-secret=notUsed
 spring.security.oauth2.client.provider.antu.token-uri=https://notUsed
 antu.oauth2.client.audience=https://notUsed
 
-# Authorization
-antu.security.authorization-service=token-based
-
 # Validation parameters
 antu.validation.additional-allowed-codespaces[0].xmlns=NSR
 antu.validation.additional-allowed-codespaces[0].xmlns-url=http://www.rutebanken.org/ns/nsr


### PR DESCRIPTION
This PR adds authentication testing to the REST integration test, similar to entur/marduk#739.

Changes:
- Created TestRutebankenAuthorizationService that implements AuthorizationService<String>
- Registered the test authorization service as a bean in the test configuration
- Removed the `antu.security.authorization-service=token-based` property from test resources
- Removed the @MockBean annotation and mocking code, using a real test implementation instead

The test implementation verifies that the security context is properly set up and authenticated.