### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v5
@@ -20,7 +20,7 @@ jobs:
           java-version: 17
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-
       - name: Run maven build
         run: mvn verify -PprettierCheck -Dprettier.nodePath=node -Dprettier.npmPath=npm
-      - uses: actions/upload-artifact@v5.0.0
+      - uses: actions/upload-artifact@v7
         with:
           path: target/*-SNAPSHOT.jar
       - name: Sonar Scan


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v5 to v6
- Update `actions/cache` from v4 to v5
- Update `actions/upload-artifact` from v5.0.0 to v7

Combines Renovate PRs #833, #850, and #851 into a single PR.

## Test plan
- [ ] Verify CI workflow runs successfully with the updated actions