### PR TITLE
Makes AuthorityRef validator configurable

### DIFF
--- a/helm/antu/env/values-kub-ent-dev.yaml
+++ b/helm/antu/env/values-kub-ent-dev.yaml
@@ -10,6 +10,7 @@ antu:
         xmlnsUrl: http://www.rutebanken.org/ns/pen
       - xmlns: NOG
         xmlnsUrl: http://www.rutebanken.org/ns/nog
+    additionalAllowedOrganisations: []
 
 gcp:
   blobstoreProjectId: en-antu-dev

--- a/helm/antu/env/values-kub-ent-prd.yaml
+++ b/helm/antu/env/values-kub-ent-prd.yaml
@@ -8,6 +8,7 @@ antu:
         xmlnsUrl: http://www.rutebanken.org/ns/nsr
       - xmlns: PEN
         xmlnsUrl: http://www.rutebanken.org/ns/pen
+    additionalAllowedOrganisations: []
 
 gcp:
   blobstoreProjectId: entur-ror-prod

--- a/helm/antu/env/values-kub-ent-tst.yaml
+++ b/helm/antu/env/values-kub-ent-tst.yaml
@@ -8,6 +8,8 @@ antu:
         xmlnsUrl: http://www.rutebanken.org/ns/nsr
       - xmlns: PEN
         xmlnsUrl: http://www.rutebanken.org/ns/pen
+    additionalAllowedOrganisations:
+      - AAS:Authority:500004
 
 gcp:
   blobstoreProjectId: entur-ror-test
@@ -22,7 +24,7 @@ gcp:
 
 tiamatUrl: http://tiamat.tst.entur.internal/services/stop_places
 
-agreementRegistryUrl: https://api.staging.entur.io/agreements/v1
+agreementRegistryUrl: https://api.entur.io/agreements/v1
 
 interchangeWaitingTimeValidationEnabled: true
 alightingAndBoardingValidationEnabled: true

--- a/helm/antu/templates/configmap.yaml
+++ b/helm/antu/templates/configmap.yaml
@@ -127,6 +127,11 @@ data:
     antu.validation.additional-allowed-codespaces[{{ $index }}].xmlns={{ $allowedCodespace.xmlns }}
     antu.validation.additional-allowed-codespaces[{{ $index }}].xmlnsUrl={{ $allowedCodespace.xmlnsUrl }}
     {{- end }}
+
+    # Additional allowed organisations for Antu validation
+    {{- range $index, $org := .Values.antu.validation.additionalAllowedOrganisations }}
+    antu.validation.additional-allowed-organisations[{{ $index }}]={{ $org }}
+    {{- end }}
 kind: ConfigMap
 metadata:
   name: {{ template "antu.name" . }}-config

--- a/src/main/java/no/entur/antu/config/ValidationParametersConfig.java
+++ b/src/main/java/no/entur/antu/config/ValidationParametersConfig.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 public class ValidationParametersConfig {
 
   private Set<NetexCodespace> additionalAllowedCodespaces;
+  private Set<String> additionalAllowedOrganisations;
 
   public Set<NetexCodespace> getAdditionalAllowedCodespaces() {
     return additionalAllowedCodespaces;
@@ -19,5 +20,15 @@ public class ValidationParametersConfig {
     Set<NetexCodespace> additionalAllowedCodespaces
   ) {
     this.additionalAllowedCodespaces = additionalAllowedCodespaces;
+  }
+
+  public Set<String> getAdditionalAllowedOrganisations() {
+    return additionalAllowedOrganisations;
+  }
+
+  public void setAdditionalAllowedOrganisations(
+    Set<String> additionalAllowedOrganisations
+  ) {
+    this.additionalAllowedOrganisations = additionalAllowedOrganisations;
   }
 }

--- a/src/main/java/no/entur/antu/validation/validator/xpath/EnturTimetableDataValidationTreeFactory.java
+++ b/src/main/java/no/entur/antu/validation/validator/xpath/EnturTimetableDataValidationTreeFactory.java
@@ -32,7 +32,12 @@ public class EnturTimetableDataValidationTreeFactory
   public ValidationTreeBuilder builder() {
     // Validation against the Norwegian organisation register
     serviceFrameValidationTreeBuilder()
-      .withRule(new ValidateAuthorityRef(organisationAliasRepository));
+      .withRule(
+        new ValidateAuthorityRef(
+          organisationAliasRepository,
+          validationParametersConfig.getAdditionalAllowedOrganisations()
+        )
+      );
     // Validation against Norwegian codespaces
     compositeFrameValidationTreeBuilder().withRule(new ValidateNSRCodespace());
 

--- a/src/main/java/no/entur/antu/validation/validator/xpath/rules/ValidateAuthorityRef.java
+++ b/src/main/java/no/entur/antu/validation/validator/xpath/rules/ValidateAuthorityRef.java
@@ -3,6 +3,7 @@ package no.entur.antu.validation.validator.xpath.rules;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XPathSelector;
 import net.sf.saxon.s9api.XdmNode;
@@ -30,16 +31,25 @@ public class ValidateAuthorityRef extends AbstractXPathValidationRule {
   );
 
   private final OrganisationAliasRepository organisationAliasRepository;
+  private final Set<String> additionalAllowedOrganisations;
 
   public ValidateAuthorityRef(
-    OrganisationAliasRepository organisationAliasRepository
+    OrganisationAliasRepository organisationAliasRepository,
+    Set<String> additionalAllowedOrganisations
   ) {
     this.organisationAliasRepository =
       Objects.requireNonNull(organisationAliasRepository);
+    this.additionalAllowedOrganisations =
+      additionalAllowedOrganisations != null
+        ? additionalAllowedOrganisations
+        : Set.of();
   }
 
   private Boolean organisationExists(String authorityRef) {
-    return organisationAliasRepository.hasOrganisationWithAlias(authorityRef);
+    return (
+      additionalAllowedOrganisations.contains(authorityRef) ||
+      organisationAliasRepository.hasOrganisationWithAlias(authorityRef)
+    );
   }
 
   @Override

--- a/src/test/java/no/entur/antu/config/TestConfig.java
+++ b/src/test/java/no/entur/antu/config/TestConfig.java
@@ -42,6 +42,7 @@ public class TestConfig {
     validationParametersConfig.setAdditionalAllowedCodespaces(
       Set.of(NetexCodespace.rutebanken("nsr"), NetexCodespace.rutebanken("pen"))
     );
+    validationParametersConfig.setAdditionalAllowedOrganisations(Set.of());
     return validationParametersConfig;
   }
 

--- a/src/test/java/no/entur/antu/validation/validator/xpath/rules/ValidateAuthorityRefTest.java
+++ b/src/test/java/no/entur/antu/validation/validator/xpath/rules/ValidateAuthorityRefTest.java
@@ -20,6 +20,8 @@ class ValidateAuthorityRefTest {
 
   private final String EXISTING_ORGANISATION_ALIAS = "OrganisationAlias:1";
   private final String NON_EXISTENT_ORGANISATION_ALIAS = "OrganisationAlias:2";
+  private final String ADDITIONAL_ALLOWED_ORGANISATION =
+    "AdditionalOrganisation:1";
 
   @BeforeEach
   public void setUp() {
@@ -27,7 +29,8 @@ class ValidateAuthorityRefTest {
       new SimpleOrganisationAliasRepository(
         Set.of(EXISTING_ORGANISATION_ALIAS)
       );
-    this.validator = new ValidateAuthorityRef(organisationAliasRepository);
+    this.validator =
+      new ValidateAuthorityRef(organisationAliasRepository, Set.of());
   }
 
   @Test
@@ -49,6 +52,24 @@ class ValidateAuthorityRefTest {
     );
     assertEquals(1, validationIssues.size());
     assertEquals(INVALID_AUTHORITY_REF_RULE, validationIssues.get(0).rule());
+  }
+
+  @Test
+  void testAdditionalAllowedOrganisation() {
+    OrganisationAliasRepository organisationAliasRepository =
+      new SimpleOrganisationAliasRepository(
+        Set.of(EXISTING_ORGANISATION_ALIAS)
+      );
+    ValidateAuthorityRef validatorWithAdditional = new ValidateAuthorityRef(
+      organisationAliasRepository,
+      Set.of(ADDITIONAL_ALLOWED_ORGANISATION)
+    );
+    XPathRuleValidationContext validationContext =
+      validationContextWithAuthorityRef(ADDITIONAL_ALLOWED_ORGANISATION);
+    List<ValidationIssue> validationIssues = validatorWithAdditional.validate(
+      validationContext
+    );
+    assertTrue(validationIssues.isEmpty());
   }
 
   private static final String NETEX_FRAGMENT =


### PR DESCRIPTION
Adds functionality that allows for configuring additional allowed organisations (per environment) in the AuthorityRef field.

The commit also adds AAS:Authority:500004 as an allowed authority in the tst environment, and updates agreementRegistryUrl in tst to https://api.entur.io/agreements/v1.