### PR TITLE
Makes OperatorRef required on Line

### DIFF
--- a/src/main/java/no/entur/antu/validation/validator/line/MissingOperatorRefOnLine.java
+++ b/src/main/java/no/entur/antu/validation/validator/line/MissingOperatorRefOnLine.java
@@ -1,0 +1,20 @@
+package no.entur.antu.validation.validator.line;
+
+import org.entur.netex.validation.validator.Severity;
+import org.entur.netex.validation.validator.xpath.rules.ValidateNotExist;
+
+/**
+ * Validate that OperatorRef is present on Line.
+ */
+public class MissingOperatorRefOnLine extends ValidateNotExist {
+
+  public MissingOperatorRefOnLine() {
+    super(
+      "lines/Line[not(OperatorRef)]",
+      "MISSING_OPERATOR_REF_ON_LINE",
+      "OperatorRef is required on Line",
+      "OperatorRef is required on Line",
+      Severity.WARNING
+    );
+  }
+}

--- a/src/main/java/no/entur/antu/validation/validator/xpath/EnturTimetableDataValidationTreeFactory.java
+++ b/src/main/java/no/entur/antu/validation/validator/xpath/EnturTimetableDataValidationTreeFactory.java
@@ -3,6 +3,7 @@ package no.entur.antu.validation.validator.xpath;
 import no.entur.antu.config.ValidationParametersConfig;
 import no.entur.antu.validation.validator.journeypattern.stoppoint.NoAlightingAtFirstStopPoint;
 import no.entur.antu.validation.validator.journeypattern.stoppoint.NoBoardingAtLastStopPoint;
+import no.entur.antu.validation.validator.line.MissingOperatorRefOnLine;
 import no.entur.antu.validation.validator.organisation.OrganisationAliasRepository;
 import no.entur.antu.validation.validator.xpath.rules.ValidateAllowedCodespaces;
 import no.entur.antu.validation.validator.xpath.rules.ValidateAuthorityRef;
@@ -60,6 +61,9 @@ public class EnturTimetableDataValidationTreeFactory
     // No alighting at first stop point in journey pattern
     serviceFrameValidationTreeBuilder()
       .withRuleForLineFile(new NoAlightingAtFirstStopPoint());
+    // OperatorRef is required on Line
+    serviceFrameValidationTreeBuilder()
+      .withRuleForLineFile(new MissingOperatorRefOnLine());
     return super.builder();
   }
 }

--- a/src/test/java/no/entur/antu/netextestdata/NetexEntitiesTestFactory.java
+++ b/src/test/java/no/entur/antu/netextestdata/NetexEntitiesTestFactory.java
@@ -549,6 +549,10 @@ public class NetexEntitiesTestFactory {
       .withRef("TST:ScheduledStopPoint:" + id);
   }
 
+  public static OperatorRefStructure createOperatorRef(int id) {
+    return new OperatorRefStructure().withRef("TST:Operator:" + id);
+  }
+
   /**
    * Creates the new QuayRefStructure with the given id
    *
@@ -921,6 +925,7 @@ public class NetexEntitiesTestFactory {
 
     protected AllVehicleModesOfTransportEnumeration transportMode;
     protected TransportSubmodeStructure transportSubmode;
+    protected OperatorRefStructure operatorRef;
 
     public CreateGenericLine(int id) {
       super(id);
@@ -939,6 +944,13 @@ public class NetexEntitiesTestFactory {
       this.transportSubmode = transportSubmode;
       return this;
     }
+
+    public CreateGenericLine<T> withOperatorRef(
+      OperatorRefStructure operatorRef
+    ) {
+      this.operatorRef = operatorRef;
+      return this;
+    }
   }
 
   public static class CreateLine extends CreateGenericLine<Line> {
@@ -952,7 +964,8 @@ public class NetexEntitiesTestFactory {
         .withId(ref())
         .withName(new MultilingualString().withValue("Line " + id))
         .withTransportMode(transportMode)
-        .withTransportSubmode(transportSubmode);
+        .withTransportSubmode(transportSubmode)
+        .withOperatorRef(operatorRef);
     }
   }
 
@@ -978,7 +991,8 @@ public class NetexEntitiesTestFactory {
         .withFlexibleLineType(flexibleLineType)
         .withName(new MultilingualString().withValue("FlexibleLine " + id))
         .withTransportMode(transportMode)
-        .withTransportSubmode(transportSubmode);
+        .withTransportSubmode(transportSubmode)
+        .withOperatorRef(operatorRef);
     }
   }
 

--- a/src/test/java/no/entur/antu/validation/validator/line/MissingOperatorRefOnLineTest.java
+++ b/src/test/java/no/entur/antu/validation/validator/line/MissingOperatorRefOnLineTest.java
@@ -1,0 +1,55 @@
+package no.entur.antu.validation.validator.line;
+
+import java.util.List;
+import org.entur.netex.validation.test.xpath.support.TestValidationContextBuilder;
+import org.entur.netex.validation.validator.ValidationIssue;
+import org.entur.netex.validation.validator.xpath.XPathRuleValidationContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MissingOperatorRefOnLineTest {
+
+  private static final String LINE_WITH_OPERATOR_REF =
+    """
+    <ServiceFrame xmlns="http://www.netex.org.uk/netex" version="1" id="TST:ServiceFrame:1">
+      <lines>
+        <Line version="1" id="TST:Line:1">
+          <Name>Test Line</Name>
+          <OperatorRef ref="TST:Operator:1"/>
+        </Line>
+      </lines>
+    </ServiceFrame>
+    """;
+
+  private static final String LINE_WITHOUT_OPERATOR_REF =
+    """
+    <ServiceFrame xmlns="http://www.netex.org.uk/netex" version="1" id="TST:ServiceFrame:1">
+      <lines>
+        <Line version="1" id="TST:Line:1">
+          <Name>Test Line</Name>
+        </Line>
+      </lines>
+    </ServiceFrame>
+    """;
+
+  @Test
+  void lineWithOperatorRefShouldNotProduceValidationIssue() {
+    List<ValidationIssue> issues = runTestWith(LINE_WITH_OPERATOR_REF);
+    Assertions.assertTrue(issues.isEmpty());
+  }
+
+  @Test
+  void lineWithoutOperatorRefShouldProduceValidationIssue() {
+    List<ValidationIssue> issues = runTestWith(LINE_WITHOUT_OPERATOR_REF);
+    Assertions.assertFalse(issues.isEmpty());
+    Assertions.assertEquals(1, issues.size());
+  }
+
+  private List<ValidationIssue> runTestWith(String netexFragment) {
+    XPathRuleValidationContext context = TestValidationContextBuilder
+      .ofNetexFragment(netexFragment)
+      .withCodespace("TST")
+      .build();
+    return new MissingOperatorRefOnLine().validate(context);
+  }
+}


### PR DESCRIPTION
This commit adds a new validator that create validation issues for every Line that have no OperatorRef. For now, this type of validation issue is reported with WARNING severity, but will likely be adjusted to ERROR severity later on.