### PR TITLE
Fixes and safeguards against null ReportCreationDate

### DIFF
--- a/src/main/java/no/entur/antu/metrics/AntuPrometheusMetricsService.java
+++ b/src/main/java/no/entur/antu/metrics/AntuPrometheusMetricsService.java
@@ -12,10 +12,16 @@ import java.util.List;
 import org.apache.camel.Handler;
 import org.apache.camel.Header;
 import org.entur.netex.validation.validator.ValidationReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AntuPrometheusMetricsService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+    AntuPrometheusMetricsService.class
+  );
 
   private static final String METRICS_PREFIX = "app.antu.";
   private static final String VALIDATION_ENTRIES_COUNTER_NAME =
@@ -57,6 +63,14 @@ public class AntuPrometheusMetricsService {
     ValidationReport validationReport,
     LocalDateTime reportCreationDate
   ) {
+    if (reportCreationDate == null) {
+      LOGGER.warn(
+        "Missing {} header for codespace {}, skipping validation time metric",
+        REPORT_CREATION_DATE,
+        validationReport.getCodespace()
+      );
+      return;
+    }
     long seconds = Duration
       .between(reportCreationDate, LocalDateTime.now())
       .toSeconds();

--- a/src/main/java/no/entur/antu/routes/validation/AggregateValidationReportsRouteBuilder.java
+++ b/src/main/java/no/entur/antu/routes/validation/AggregateValidationReportsRouteBuilder.java
@@ -409,6 +409,14 @@ public class AggregateValidationReportsRouteBuilder extends BaseRouteBuilder {
         oldExchange == null ||
         oldExchange.getIn().getBody(ValidationReport.class) == null
       ) {
+        ValidationReport report = newExchange
+          .getIn()
+          .getBody(ValidationReport.class);
+        if (report != null && report.getCreationDate() != null) {
+          newExchange
+            .getIn()
+            .setHeader(REPORT_CREATION_DATE, report.getCreationDate());
+        }
         return newExchange;
       }
 


### PR DESCRIPTION
* ReportCreationDate sporadically ends up being null when reporting metrics to prometheus
* This commit attempts to fix the root cause of this, and adds a safeguard in the prometheus metrics reporting that ensures the entire validation does not fail because of a failing metric