### PR TITLE
Coupled dependency upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <java.version>17</java.version>
         <camel.version>4.10.9</camel.version>
-        <entur.helpers.version>5.50.0</entur.helpers.version>
+        <entur.helpers.version>7.1.0</entur.helpers.version>
         <netex-validator-java.version>11.0.31</netex-validator-java.version>
         <netex-parser-java.version>3.1.78</netex-parser-java.version>
         <jts-core.version>1.20.0</jts-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <!--Used by Spring Actuator to expose metrics to Prometheus-->

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,16 @@
 
         <!-- testing -->
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>4.10.0</version>
+        <version>6.4.0</version>
     </parent>
 
     <groupId>no.entur.antu</groupId>
@@ -31,7 +31,8 @@
         <jts-core.version>1.20.0</jts-core.version>
         <commons-io.version>2.11.0</commons-io.version>
         <zt-zip.version>1.17</zt-zip.version>
-        <redisson.version>3.52.0</redisson.version>
+        <redisson.version>4.5.0</redisson.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <kryo.version>5.6.2</kryo.version>
         <embedded-redis.version>0.9.1</embedded-redis.version>
         <prettier-java.version>2.1.0</prettier-java.version>
@@ -51,6 +52,14 @@
                 <groupId>org.apache.camel.springboot</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
                 <version>${camel.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/no/entur/antu/App.java
+++ b/src/main/java/no/entur/antu/App.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 /**

--- a/src/main/java/no/entur/antu/config/AuthorizationConfig.java
+++ b/src/main/java/no/entur/antu/config/AuthorizationConfig.java
@@ -21,7 +21,6 @@ import java.util.Locale;
 import no.entur.antu.security.AntuAuthorizationService;
 import no.entur.antu.security.DefaultAntuAuthorizationService;
 import org.entur.oauth2.AuthorizedWebClientBuilder;
-import org.entur.oauth2.JwtRoleAssignmentExtractor;
 import org.entur.ror.permission.RemoteBabaRoleAssignmentExtractor;
 import org.rutebanken.helper.organisation.RoleAssignmentExtractor;
 import org.rutebanken.helper.organisation.authorization.AuthorizationService;
@@ -41,16 +40,6 @@ import org.springframework.web.reactive.function.client.WebClient;
  */
 @Configuration
 public class AuthorizationConfig {
-
-  @ConditionalOnProperty(
-    value = "antu.security.role.assignment.extractor",
-    havingValue = "jwt",
-    matchIfMissing = true
-  )
-  @Bean
-  public RoleAssignmentExtractor jwtRoleAssignmentExtractor() {
-    return new JwtRoleAssignmentExtractor();
-  }
 
   @ConditionalOnProperty(
     value = "antu.security.role.assignment.extractor",

--- a/src/main/java/no/entur/antu/config/AuthorizationConfig.java
+++ b/src/main/java/no/entur/antu/config/AuthorizationConfig.java
@@ -30,7 +30,7 @@ import org.rutebanken.helper.organisation.authorization.FullAccessAuthorizationS
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManagerResolver;

--- a/src/main/java/no/entur/antu/config/RedisClientConfig.java
+++ b/src/main/java/no/entur/antu/config/RedisClientConfig.java
@@ -52,12 +52,10 @@ public class RedisClientConfig {
         redisProperties.getHost(),
         redisProperties.getPort()
       );
-      redissonConfig
-        .useSingleServer()
-        .setAddress(address)
-        .setSslTruststore(new File(trustStoreFile).toURI().toURL())
-        .setSslTruststorePassword(trustStorePassword)
-        .setPassword(authenticationString);
+      redissonConfig.useSingleServer().setAddress(address);
+      redissonConfig.setSslTruststore(new File(trustStoreFile).toURI().toURL());
+      redissonConfig.setSslTruststorePassword(trustStorePassword);
+      redissonConfig.setPassword(authenticationString);
       return redissonConfig;
     }
   }

--- a/src/main/java/no/entur/antu/config/RedisClientConfig.java
+++ b/src/main/java/no/entur/antu/config/RedisClientConfig.java
@@ -10,7 +10,7 @@ import org.redisson.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -24,7 +24,7 @@ public class RedisClientConfig {
 
   @Bean
   public Config redissonConfig(
-    RedisProperties redisProperties,
+    DataRedisProperties redisProperties,
     @Value("${antu.redis.server.trust.store.file:}") String trustStoreFile,
     @Value(
       "${antu.redis.server.trust.store.password:}"

--- a/src/main/java/no/entur/antu/security/oauth2/AntuWebSecurityConfiguration.java
+++ b/src/main/java/no/entur/antu/security/oauth2/AntuWebSecurityConfiguration.java
@@ -58,7 +58,7 @@ public class AntuWebSecurityConfiguration {
   public SecurityFilterChain filterChain(
     HttpSecurity http,
     MultiIssuerAuthenticationManagerResolver multiIssuerAuthenticationManagerResolver
-  ) throws Exception {
+  ) {
     http
       .cors(withDefaults())
       .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/no/entur/antu/security/oauth2/AntuWebSecurityConfiguration.java
+++ b/src/main/java/no/entur/antu/security/oauth2/AntuWebSecurityConfiguration.java
@@ -12,7 +12,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -65,31 +64,19 @@ public class AntuWebSecurityConfiguration {
       .csrf(AbstractHttpConfigurer::disable)
       .authorizeHttpRequests(authz ->
         authz
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher(
-              "/services/validation-report/swagger.json"
-            )
-          )
+          .requestMatchers("/services/validation-report/swagger.json")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/services/swagger.json")
-          )
+          .requestMatchers("/services/swagger.json")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/prometheus")
-          )
+          .requestMatchers("/actuator/prometheus")
           .permitAll()
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/health"))
+          .requestMatchers("/actuator/health")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/health/liveness")
-          )
+          .requestMatchers("/actuator/health/liveness")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/health/readiness")
-          )
+          .requestMatchers("/actuator/health/readiness")
           .permitAll()
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/info"))
+          .requestMatchers("/actuator/info")
           .permitAll()
           .anyRequest()
           .authenticated()

--- a/src/test/java/no/entur/antu/TestApp.java
+++ b/src/test/java/no/entur/antu/TestApp.java
@@ -20,7 +20,7 @@ package no.entur.antu;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 

--- a/src/test/java/no/entur/antu/config/RedisClientConfigTest.java
+++ b/src/test/java/no/entur/antu/config/RedisClientConfigTest.java
@@ -1,0 +1,51 @@
+package no.entur.antu.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.redisson.config.Config;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties;
+
+class RedisClientConfigTest {
+
+  private final RedisClientConfig redisClientConfig = new RedisClientConfig();
+
+  @Test
+  void nonEncryptedConnectionHasNoSslConfig() throws MalformedURLException {
+    DataRedisProperties props = new DataRedisProperties();
+    props.setHost("localhost");
+    props.setPort(6379);
+
+    Config config = redisClientConfig.redissonConfig(props, "", "", "");
+
+    assertNull(config.getSslTruststore());
+    assertNull(config.getPassword());
+  }
+
+  @Test
+  void encryptedConnectionSetsSslAndPassword(@TempDir File tempDir)
+    throws MalformedURLException {
+    DataRedisProperties props = new DataRedisProperties();
+    props.setHost("localhost");
+    props.setPort(6380);
+
+    File trustStoreFile = new File(tempDir, "truststore.jks");
+
+    Config config = redisClientConfig.redissonConfig(
+      props,
+      trustStoreFile.getAbsolutePath(),
+      "test-truststore-password",
+      "test-auth-string"
+    );
+
+    assertNotNull(config.getSslTruststore());
+    assertEquals(trustStoreFile.toURI().toURL(), config.getSslTruststore());
+    assertEquals("test-truststore-password", config.getSslTruststorePassword());
+    assertEquals("test-auth-string", config.getPassword());
+  }
+}

--- a/src/test/java/no/entur/antu/config/TestRedisConfiguration.java
+++ b/src/test/java/no/entur/antu/config/TestRedisConfiguration.java
@@ -3,7 +3,7 @@ package no.entur.antu.config;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
-import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
@@ -19,7 +19,7 @@ public class TestRedisConfiguration {
   }
 
   @Bean(initMethod = "start", destroyMethod = "stop")
-  public RedisServer redissonServer(RedisProperties redisProperties) {
+  public RedisServer redissonServer(DataRedisProperties redisProperties) {
     return new RedisServer(redisProperties.getPort());
   }
 }

--- a/src/test/java/no/entur/antu/routes/rest/RestValidationReportRouteBuilderIntegrationTest.java
+++ b/src/test/java/no/entur/antu/routes/rest/RestValidationReportRouteBuilderIntegrationTest.java
@@ -53,7 +53,6 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -105,25 +104,15 @@ class RestValidationReportRouteBuilderIntegrationTest
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authz ->
           authz
-            .requestMatchers(
-              AntPathRequestMatcher.antMatcher("/services/openapi.json")
-            )
+            .requestMatchers("/services/openapi.json")
             .permitAll()
-            .requestMatchers(
-              AntPathRequestMatcher.antMatcher("/actuator/prometheus")
-            )
+            .requestMatchers("/actuator/prometheus")
             .permitAll()
-            .requestMatchers(
-              AntPathRequestMatcher.antMatcher("/actuator/health")
-            )
+            .requestMatchers("/actuator/health")
             .permitAll()
-            .requestMatchers(
-              AntPathRequestMatcher.antMatcher("/actuator/health/liveness")
-            )
+            .requestMatchers("/actuator/health/liveness")
             .permitAll()
-            .requestMatchers(
-              AntPathRequestMatcher.antMatcher("/actuator/health/readiness")
-            )
+            .requestMatchers("/actuator/health/readiness")
             .permitAll()
             .anyRequest()
             .authenticated()

--- a/src/test/java/no/entur/antu/routes/rest/RestValidationReportRouteBuilderIntegrationTest.java
+++ b/src/test/java/no/entur/antu/routes/rest/RestValidationReportRouteBuilderIntegrationTest.java
@@ -98,7 +98,7 @@ class RestValidationReportRouteBuilderIntegrationTest
 
     @Bean
     @ConditionalOnWebApplication
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http) {
       http
         .cors(withDefaults())
         .csrf(AbstractHttpConfigurer::disable)

--- a/src/test/java/no/entur/antu/security/oauth2/AntuWebSecurityConfigurationTest.java
+++ b/src/test/java/no/entur/antu/security/oauth2/AntuWebSecurityConfigurationTest.java
@@ -1,0 +1,73 @@
+package no.entur.antu.security.oauth2;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureWebMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(
+  webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+  classes = AntuWebSecurityConfigurationTest.MinimalConfig.class
+)
+@AutoConfigureWebMvc
+@AutoConfigureMockMvc
+class AntuWebSecurityConfigurationTest {
+
+  @SpringBootConfiguration
+  @EnableWebSecurity
+  @Import(AntuWebSecurityConfiguration.class)
+  @ImportAutoConfiguration(exclude = UserDetailsServiceAutoConfiguration.class)
+  static class MinimalConfig {}
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private MultiIssuerAuthenticationManagerResolver multiIssuerAuthenticationManagerResolver;
+
+  @MockitoBean
+  private ClientRegistrationRepository clientRegistrationRepository;
+
+  @ParameterizedTest
+  @ValueSource(
+    strings = {
+      "/services/validation-report/swagger.json",
+      "/services/swagger.json",
+      "/actuator/prometheus",
+      "/actuator/health",
+      "/actuator/health/liveness",
+      "/actuator/health/readiness",
+      "/actuator/info",
+    }
+  )
+  void publicEndpointsDoNotRequireAuthentication(String path) throws Exception {
+    mockMvc
+      .perform(get(path))
+      .andExpect(status().is(not(equalTo(HttpStatus.UNAUTHORIZED.value()))));
+  }
+
+  @Test
+  void otherEndpointsRequireAuthentication() throws Exception {
+    mockMvc
+      .perform(get("/some-protected-endpoint"))
+      .andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
Closes #859 
Closes #854 
Closes #884 

The following upgrades are done by this commit:
- entur-helpers to v7
- superpom to 6.4.0
- redisson to 4.5.0

These three upgrades are coupled:
- entur-helpers v7 pulls in spring-boot-security 4.x artifacts, conflicting with the Spring Boot 3.x managed by superpom 4.x
- superpom 6.4.0 aligns the project to Spring Boot 4.0.6, resolving the conflict. The PR also adds testcontainers-bom (dropped from Spring Boot 4.x BOM) and fixes references to relocated classes in Spring.
- redisson-spring-boot-starter 3.x was compiled against Spring Boot 3.x and references removed classes at runtime; 4.5.0 adds Spring Boot 4.x support. Bumping redisson to 4.x in a separate PR was considered, but this would need manual configuration to work with Spring Boot 3.x. Not worth it imo.

Possible risk assessed: A major upgrade of Redisson could potentially have lead to serialization failures between old and new antu pods, if the Kryo5 serialization format differed between the two. I have verified that the two versions of Redisson use the same Kryo version (`com.esotericsoftware:kryo:5.6.2`), so this should not be an issue.

Things verified locally:
- Antu is running well with my local development config, and validates a medium-sized dataset without problems. Dataset also contained Interchanges which is written to and read from a local Redis cache during validation.
- Antu is still responding with 401 when receiving unauthorized requests at secured endpoints.