### PR TITLE
Interchange Waiting Time validator fix

### DIFF
--- a/src/main/java/no/entur/antu/netexdata/collectors/ServiceJourneyActiveDatesCollector.java
+++ b/src/main/java/no/entur/antu/netexdata/collectors/ServiceJourneyActiveDatesCollector.java
@@ -299,7 +299,7 @@ public class ServiceJourneyActiveDatesCollector extends NetexDataCollector {
     }
   }
 
-  private LocalDateTime getFromDateFromOperatingPeriod(
+  static LocalDateTime getFromDateFromOperatingPeriod(
     OperatingPeriod operatingPeriod,
     Map<String, LocalDateTime> operatingDayRefsToCalendarDate
   ) {
@@ -311,7 +311,7 @@ public class ServiceJourneyActiveDatesCollector extends NetexDataCollector {
     );
   }
 
-  private LocalDateTime getToDateFromOperatingPeriod(
+  static LocalDateTime getToDateFromOperatingPeriod(
     OperatingPeriod operatingPeriod,
     Map<String, LocalDateTime> operatingDayRefsToCalendarDate
   ) {
@@ -323,7 +323,7 @@ public class ServiceJourneyActiveDatesCollector extends NetexDataCollector {
     );
   }
 
-  private Set<LocalDateTime> computeDatesForPeriodAndWeekday(
+  static Set<LocalDateTime> computeDatesForPeriodAndWeekday(
     OperatingPeriod period,
     Set<DayOfWeekEnumeration> daysOfWeekEnumeration,
     Map<String, LocalDateTime> operatingDayRefsToCalendarDate
@@ -338,7 +338,7 @@ public class ServiceJourneyActiveDatesCollector extends NetexDataCollector {
       period,
       operatingDayRefsToCalendarDate
     );
-    for (LocalDateTime d = fromDate; d.isBefore(toDate); d = d.plusDays(1)) {
+    for (LocalDateTime d = fromDate; !d.isAfter(toDate); d = d.plusDays(1)) {
       if (daysOfWeek.contains(d.getDayOfWeek())) {
         dates.add(d);
       }

--- a/src/test/java/no/entur/antu/netexdata/collectors/ServiceJourneyActiveDatesCollectorTest.java
+++ b/src/test/java/no/entur/antu/netexdata/collectors/ServiceJourneyActiveDatesCollectorTest.java
@@ -3,9 +3,12 @@ package no.entur.antu.netexdata.collectors;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.rutebanken.netex.model.DayOfWeekEnumeration;
+import org.rutebanken.netex.model.OperatingPeriod;
 
 class ServiceJourneyActiveDatesCollectorTest {
 
@@ -57,5 +60,28 @@ class ServiceJourneyActiveDatesCollectorTest {
         DayOfWeekEnumeration.NONE
       );
     assertEquals(0, dayOfWeekSet.size());
+  }
+
+  @Test
+  void testSingleDayOperatingPeriodIncludesTheDay() {
+    // 2025-01-15 is a Wednesday — covered by WEEKDAYS
+    LocalDateTime singleDay = LocalDateTime.of(2025, 1, 15, 0, 0, 0);
+    OperatingPeriod period = new OperatingPeriod()
+      .withFromDate(singleDay)
+      .withToDate(singleDay);
+
+    Set<LocalDateTime> dates =
+      ServiceJourneyActiveDatesCollector.computeDatesForPeriodAndWeekday(
+        period,
+        Set.of(DayOfWeekEnumeration.WEEKDAYS),
+        Map.of()
+      );
+
+    assertEquals(
+      1,
+      dates.size(),
+      "A single-day OperatingPeriod (FromDate == ToDate) must include that day"
+    );
+    assertTrue(dates.contains(singleDay));
   }
 }

--- a/src/test/java/no/entur/antu/netexdata/collectors/ServiceJourneyActiveDatesCollectorTest.java
+++ b/src/test/java/no/entur/antu/netexdata/collectors/ServiceJourneyActiveDatesCollectorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -65,7 +66,14 @@ class ServiceJourneyActiveDatesCollectorTest {
   @Test
   void testSingleDayOperatingPeriodIncludesTheDay() {
     // 2025-01-15 is a Wednesday — covered by WEEKDAYS
-    LocalDateTime singleDay = LocalDateTime.of(2025, 1, 15, 0, 0, 0);
+    LocalDateTime singleDay = LocalDateTime.of(
+      2025,
+      Month.JANUARY,
+      15,
+      0,
+      0,
+      0
+    );
     OperatingPeriod period = new OperatingPeriod()
       .withFromDate(singleDay)
       .withToDate(singleDay);


### PR DESCRIPTION
Ensures that OperatingPeriod with equal FromDate and ToDate are interpreted as a single running date, rather than 0 running dates, by the InterchangeWaitingTimeValidator. This bug resulted in creating validation issues on no interchange possible for journeys running on a single date only.