### PR TITLE
Upgrade Apache Camel to 4.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </scm>
     <properties>
         <java.version>17</java.version>
-        <camel.version>4.10.9</camel.version>
+        <camel.version>4.18.2</camel.version>
         <entur.helpers.version>5.50.0</entur.helpers.version>
         <netex-validator-java.version>11.0.31</netex-validator-java.version>
         <netex-parser-java.version>3.1.78</netex-parser-java.version>
@@ -261,6 +261,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-test-spring-junit5</artifactId>
+            <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bump camel.version from 4.10.9 to 4.18.2 and pin camel-test-spring-junit5 to ${camel.version}; the 4.18 BOM no longer manages it.