### PR TITLE
Improves AuthorityRef validation

### DIFF
--- a/src/main/java/no/entur/antu/validation/validator/xpath/rules/ValidateAuthorityRef.java
+++ b/src/main/java/no/entur/antu/validation/validator/xpath/rules/ValidateAuthorityRef.java
@@ -23,12 +23,27 @@ import org.entur.netex.validation.validator.xpath.XPathRuleValidationContext;
 public class ValidateAuthorityRef extends AbstractXPathValidationRule {
 
   public static final String CODE_AUTHORITY_REF = "AUTHORITY_REF";
+  public static final String CODE_AUTHORITY_REF_IN_ADDITIONAL_NETWORKS =
+    "AUTHORITY_REF_IN_ADDITIONAL_NETWORKS";
+
   static final ValidationRule INVALID_AUTHORITY_REF_RULE = new ValidationRule(
     CODE_AUTHORITY_REF,
     "Invalid Authority Ref",
     "Authority Ref %s does not exist in the organisation registry",
     Severity.ERROR
   );
+  static final ValidationRule INVALID_AUTHORITY_REF_IN_ADDITIONAL_NETWORKS_RULE =
+    new ValidationRule(
+      CODE_AUTHORITY_REF_IN_ADDITIONAL_NETWORKS,
+      "Invalid Authority Ref in Additional Networks",
+      "Authority Ref %s does not exist in the organisation registry",
+      Severity.WARNING
+    );
+
+  private static final String XPATH_NETWORK =
+    "//ServiceFrame/Network/AuthorityRef";
+  private static final String XPATH_ADDITIONAL_NETWORKS =
+    "//ServiceFrame/additionalNetworks/Network/AuthorityRef";
 
   private final OrganisationAliasRepository organisationAliasRepository;
   private final Set<String> additionalAllowedOrganisations;
@@ -45,7 +60,7 @@ public class ValidateAuthorityRef extends AbstractXPathValidationRule {
         : Set.of();
   }
 
-  private Boolean organisationExists(String authorityRef) {
+  private boolean organisationExists(String authorityRef) {
     return (
       additionalAllowedOrganisations.contains(authorityRef) ||
       organisationAliasRepository.hasOrganisationWithAlias(authorityRef)
@@ -56,39 +71,51 @@ public class ValidateAuthorityRef extends AbstractXPathValidationRule {
   public List<ValidationIssue> validate(
     XPathRuleValidationContext validationContext
   ) {
-    String xpath = "//ServiceFrame/Network/AuthorityRef";
-    XPathSelector selector = null;
     List<ValidationIssue> validationIssues = new ArrayList<>();
     try {
-      selector =
-        validationContext
-          .getNetexXMLParser()
-          .getXPathCompiler()
-          .compile(xpath)
-          .load();
-      selector.setContextItem(validationContext.getXmlNode());
-      XdmValue nodes = selector.evaluate();
-      for (XdmValue node : nodes) {
-        XdmNode xdmNode = (XdmNode) node;
-        String authorityRef = ((XdmNode) node).attribute("ref");
-        Boolean organisationExists = this.organisationExists(authorityRef);
-        DataLocation dataLocation = getXdmNodeLocation(
-          validationContext.getFileName(),
-          xdmNode
-        );
-        if (!organisationExists) {
-          validationIssues.add(
-            new ValidationIssue(
-              INVALID_AUTHORITY_REF_RULE,
-              dataLocation,
-              authorityRef
-            )
-          );
-        }
-      }
-      return validationIssues;
+      validateAuthorityRefs(
+        validationContext,
+        XPATH_NETWORK,
+        INVALID_AUTHORITY_REF_RULE,
+        validationIssues
+      );
+      validateAuthorityRefs(
+        validationContext,
+        XPATH_ADDITIONAL_NETWORKS,
+        INVALID_AUTHORITY_REF_IN_ADDITIONAL_NETWORKS_RULE,
+        validationIssues
+      );
     } catch (SaxonApiException e) {
       throw new RuntimeException(e);
+    }
+    return validationIssues;
+  }
+
+  private void validateAuthorityRefs(
+    XPathRuleValidationContext validationContext,
+    String xpath,
+    ValidationRule rule,
+    List<ValidationIssue> validationIssues
+  ) throws SaxonApiException {
+    XPathSelector selector = validationContext
+      .getNetexXMLParser()
+      .getXPathCompiler()
+      .compile(xpath)
+      .load();
+    selector.setContextItem(validationContext.getXmlNode());
+    XdmValue nodes = selector.evaluate();
+    for (XdmValue node : nodes) {
+      XdmNode xdmNode = (XdmNode) node;
+      String authorityRef = xdmNode.attribute("ref");
+      if (!organisationExists(authorityRef)) {
+        validationIssues.add(
+          new ValidationIssue(
+            rule,
+            getXdmNodeLocation(validationContext.getFileName(), xdmNode),
+            authorityRef
+          )
+        );
+      }
     }
   }
 

--- a/src/main/java/no/entur/antu/validation/validator/xpath/rules/ValidateAuthorityRef.java
+++ b/src/main/java/no/entur/antu/validation/validator/xpath/rules/ValidateAuthorityRef.java
@@ -9,7 +9,6 @@ import net.sf.saxon.s9api.XPathSelector;
 import net.sf.saxon.s9api.XdmNode;
 import net.sf.saxon.s9api.XdmValue;
 import no.entur.antu.validation.validator.organisation.OrganisationAliasRepository;
-import org.entur.netex.validation.validator.DataLocation;
 import org.entur.netex.validation.validator.Severity;
 import org.entur.netex.validation.validator.ValidationIssue;
 import org.entur.netex.validation.validator.ValidationRule;

--- a/src/test/java/no/entur/antu/validation/validator/xpath/rules/ValidateAuthorityRefTest.java
+++ b/src/test/java/no/entur/antu/validation/validator/xpath/rules/ValidateAuthorityRefTest.java
@@ -1,5 +1,6 @@
 package no.entur.antu.validation.validator.xpath.rules;
 
+import static no.entur.antu.validation.validator.xpath.rules.ValidateAuthorityRef.INVALID_AUTHORITY_REF_IN_ADDITIONAL_NETWORKS_RULE;
 import static no.entur.antu.validation.validator.xpath.rules.ValidateAuthorityRef.INVALID_AUTHORITY_REF_RULE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -72,6 +73,34 @@ class ValidateAuthorityRefTest {
     assertTrue(validationIssues.isEmpty());
   }
 
+  @Test
+  void testInvalidAuthorityRefInAdditionalNetworks() {
+    XPathRuleValidationContext validationContext =
+      validationContextWithAdditionalNetworkAuthorityRef(
+        NON_EXISTENT_ORGANISATION_ALIAS
+      );
+    List<ValidationIssue> validationIssues = validator.validate(
+      validationContext
+    );
+    assertEquals(1, validationIssues.size());
+    assertEquals(
+      INVALID_AUTHORITY_REF_IN_ADDITIONAL_NETWORKS_RULE,
+      validationIssues.get(0).rule()
+    );
+  }
+
+  @Test
+  void testValidAuthorityRefInAdditionalNetworks() {
+    XPathRuleValidationContext validationContext =
+      validationContextWithAdditionalNetworkAuthorityRef(
+        EXISTING_ORGANISATION_ALIAS
+      );
+    List<ValidationIssue> validationIssues = validator.validate(
+      validationContext
+    );
+    assertTrue(validationIssues.isEmpty());
+  }
+
   private static final String NETEX_FRAGMENT =
     """
             <ServiceFrame xmlns="http://www.netex.org.uk/netex" version="1">
@@ -81,10 +110,35 @@ class ValidateAuthorityRefTest {
             </ServiceFrame>
         """;
 
+  private static final String NETEX_FRAGMENT_ADDITIONAL_NETWORKS =
+    """
+            <ServiceFrame xmlns="http://www.netex.org.uk/netex" version="1">
+              <Network>
+                <AuthorityRef ref="%s"></AuthorityRef>
+              </Network>
+              <additionalNetworks>
+                <Network>
+                  <AuthorityRef ref="%s"></AuthorityRef>
+                </Network>
+              </additionalNetworks>
+            </ServiceFrame>
+        """;
+
   private XPathRuleValidationContext validationContextWithAuthorityRef(
     String authorityRef
   ) {
     String netexFragment = String.format(NETEX_FRAGMENT, authorityRef);
+    return TestValidationContextBuilder.ofNetexFragment(netexFragment).build();
+  }
+
+  private XPathRuleValidationContext validationContextWithAdditionalNetworkAuthorityRef(
+    String additionalNetworkAuthorityRef
+  ) {
+    String netexFragment = String.format(
+      NETEX_FRAGMENT_ADDITIONAL_NETWORKS,
+      EXISTING_ORGANISATION_ALIAS,
+      additionalNetworkAuthorityRef
+    );
     return TestValidationContextBuilder.ofNetexFragment(netexFragment).build();
   }
 }


### PR DESCRIPTION
Ensures ValidateAuthorityRef also checks whether AuthorityRef values in `//ServiceFrame/additionalNetworks/Network/AuthorityRef` exist in the list of organisation aliases. Reports issues on WARNING severity for now.