### PR TITLE
Upgrade to Spring Boot 4

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21.0.5+11
           distribution: liberica
       - name: Cache Maven dependencies
         uses: actions/cache@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Antu is a NeTEx dataset validation service built by Entur for validating public 
 ## Architecture
 
 ### Core Components
-- **Language**: Java 17
+- **Language**: Java 21
 - **Framework**: Spring Boot with Apache Camel
 - **Build Tool**: Maven
 - **Message Queue**: Google Cloud PubSub
@@ -28,11 +28,13 @@ Antu is a NeTEx dataset validation service built by Entur for validating public 
 8. Notifies Marduk via PubSub
 
 ### Key Dependencies
-- `netex-validator-java` (v11.0.3): Core validation library
-- `netex-parser-java` (v3.1.63): NeTEx XML parsing
-- `camel-spring-boot` (v4.10.7): Integration framework
-- `redisson` (v3.52.0): Distributed data structures
-- `entur-helpers` (v5.47.0): Entur-specific utilities
+- `netex-validator-java`: Core validation library
+- `netex-parser-java`: NeTEx XML parsing
+- `camel-spring-boot`: Integration framework
+- `redisson`: Distributed data structures
+- `entur-helpers`: Entur-specific utilities
+
+Versions live in pom.xml; do not trust versions written in this file.
 
 ## Project Structure
 
@@ -79,9 +81,9 @@ Requirements:
 - Application properties file configured
 
 ```bash
-docker run -p 6379:6379 --name redis-antu redis:6
+docker run -p 6379:6379 --name redis-antu redis:7-alpine
 gcloud beta emulators pubsub start
-java -Xmx500m -Dspring.config.location=/path/to/application.properties -jar target/antu-0.0.1-SNAPSHOT.jar
+java -Xmx500m -Dspring.config.location=/path/to/application.properties -jar target/antu-*.jar
 ```
 
 ### Code Formatting

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The Kubernetes configmap helm/antu/templates/configmap.yaml can also be used as 
 
 - Run `mvn package` to generate the Spring Boot jar.
 - The application can be started with the following command line:  
-  ```java -Xmx500m -Dspring.config.location=/path/to/application.properties -Dfile.encoding=UTF-8 -jar target/antu-0.0.1-SNAPSHOT.jar```
+  ```java -Xmx500m -Dspring.config.location=/path/to/application.properties -Dfile.encoding=UTF-8 -jar target/antu-*.jar```
 
 # Antu rule set
 

--- a/helm/antu/templates/configmap.yaml
+++ b/helm/antu/templates/configmap.yaml
@@ -6,7 +6,6 @@ data:
     spring.main.sources=no.entur.antu
     spring.profiles.active=gcs-blobstore,stop-place-changelog
     server.port={{ .Values.service.http.internalPort }}
-    spring.quartz.auto-startup=false
 
     # Camel
     camel.main.name=antu
@@ -102,12 +101,11 @@ data:
 
     # Actuator
     management.endpoints.access.default=none
-    management.endpoint.info.enabled=true
-    management.endpoint.health.enabled=true
+    management.endpoint.info.access=unrestricted
+    management.endpoint.health.access=unrestricted
     management.health.defaults.enabled=false
-    management.endpoint.health.probes.enabled=true
     management.endpoint.health.group.readiness.include=readinessState
-    management.endpoint.prometheus.enabled=true
+    management.endpoint.prometheus.access=unrestricted
     management.endpoints.web.exposure.include=health,prometheus,info
     management.endpoints.jmx.exposure.exclude=*
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>4.10.0</version>
+        <version>6.5.0</version>
     </parent>
 
     <groupId>no.entur.antu</groupId>
@@ -23,15 +23,17 @@
         <developerConnection>scm:git:ssh://git@github.com:entur/antu.git</developerConnection>
     </scm>
     <properties>
-        <java.version>17</java.version>
-        <camel.version>4.18.3</camel.version>
-        <entur.helpers.version>5.50.0</entur.helpers.version>
+        <java.version>21</java.version>
+        <camel.version>4.21.0</camel.version>
+        <entur.helpers.version>7.2.0</entur.helpers.version>
+        <spring-cloud-gcp-dependencies.version>7.4.10</spring-cloud-gcp-dependencies.version>
+        <!-- unmanaged by any BOM, must track the kubernetes-client version that camel-kubernetes pulls in -->
+        <kubernetes-client.version>7.7.0</kubernetes-client.version>
         <netex-validator-java.version>11.0.31</netex-validator-java.version>
         <netex-parser-java.version>3.1.80</netex-parser-java.version>
         <jts-core.version>1.20.0</jts-core.version>
-        <commons-io.version>2.11.0</commons-io.version>
         <zt-zip.version>1.17</zt-zip.version>
-        <redisson.version>3.52.0</redisson.version>
+        <redisson.version>4.6.1</redisson.version>
         <kryo.version>5.6.2</kryo.version>
         <embedded-redis.version>0.9.1</embedded-redis.version>
         <prettier-java.version>2.1.0</prettier-java.version>
@@ -47,6 +49,28 @@
     <dependencyManagement>
         <dependencies>
 
+            <!--
+              Must precede spring-cloud-gcp-dependencies, which pins opentelemetry-api to an older
+              version than the rest of the opentelemetry modules resolve to. First declaration wins.
+            -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!--
+              entur-helpers still pins spring-cloud-gcp 5.11.3, which references Boot 3 classes that
+              no longer exist. Remove this once helpers ships a Boot 4 compatible version.
+            -->
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>spring-cloud-gcp-dependencies</artifactId>
+                <version>${spring-cloud-gcp-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.apache.camel.springboot</groupId>
                 <artifactId>camel-spring-boot-bom</artifactId>
@@ -80,20 +104,6 @@
             <groupId>org.entur.ror.helpers</groupId>
             <artifactId>storage-gcp-gcs</artifactId>
             <version>${entur.helpers.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>servlet-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-codec-http2</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-lite</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.entur.ror.helpers</groupId>
@@ -111,12 +121,24 @@
             <groupId>org.entur.ror.helpers</groupId>
             <artifactId>stopplace-changelog-starter</artifactId>
             <version>${entur.helpers.version}</version>
+            <exclusions>
+                <!-- Duplicate of swagger-annotations-jakarta, which camel-openapi-java reads -->
+                <exclusion>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Spring Boot -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <!-- WebClient auto-configuration is no longer part of the web starters in Boot 4 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webclient</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -144,6 +166,18 @@
         <dependency>
             <groupId>org.redisson</groupId>
             <artifactId>redisson-spring-boot-starter</artifactId>
+            <version>${redisson.version}</version>
+            <exclusions>
+                <!-- The starter targets Spring Boot 4.1; swap in the Spring Data Redis 4.0 module -->
+                <exclusion>
+                    <groupId>org.redisson</groupId>
+                    <artifactId>redisson-spring-data-41</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson-spring-data-40</artifactId>
             <version>${redisson.version}</version>
         </dependency>
         <!-- Used by Redisson -->
@@ -173,6 +207,19 @@
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-kubernetes-cluster-service-starter</artifactId>
+            <exclusions>
+                <!-- fabric8's default Vert.x transport is built for Netty 4.1, Spring Boot 4 forces
+                     Netty 4.2. Use the Netty-free JDK transport so k8s leader election keeps working. -->
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-vertx</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <version>${kubernetes-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
@@ -238,12 +285,12 @@
         <!-- testing -->
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>gcloud</artifactId>
+            <artifactId>testcontainers-gcloud</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,21 @@
   "baseBranchPatterns": [
     "main"
   ],
-  "separateMinorPatch": true
+  "separateMinorPatch": true,
+  "packageRules": [
+    {
+      "description": "superpom carries the Spring Boot version, never automerge",
+      "matchPackageNames": [
+        "org.entur.ror:superpom"
+      ],
+      "automerge": false
+    },
+    {
+      "description": "redisson-spring-data-40 is pinned by hand against the starter's transitive module, never automerge",
+      "matchPackageNames": [
+        "org.redisson:**"
+      ],
+      "automerge": false
+    }
+  ]
 }

--- a/src/main/java/no/entur/antu/App.java
+++ b/src/main/java/no/entur/antu/App.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
 import org.springframework.context.annotation.Import;
 
 /**

--- a/src/main/java/no/entur/antu/config/AuthorizationConfig.java
+++ b/src/main/java/no/entur/antu/config/AuthorizationConfig.java
@@ -30,7 +30,7 @@ import org.rutebanken.helper.organisation.authorization.FullAccessAuthorizationS
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManagerResolver;

--- a/src/main/java/no/entur/antu/config/RedisClientConfig.java
+++ b/src/main/java/no/entur/antu/config/RedisClientConfig.java
@@ -10,7 +10,7 @@ import org.redisson.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -24,7 +24,7 @@ public class RedisClientConfig {
 
   @Bean
   public Config redissonConfig(
-    RedisProperties redisProperties,
+    DataRedisProperties redisProperties,
     @Value("${antu.redis.server.trust.store.file:}") String trustStoreFile,
     @Value(
       "${antu.redis.server.trust.store.password:}"

--- a/src/main/java/no/entur/antu/security/oauth2/AntuWebSecurityConfiguration.java
+++ b/src/main/java/no/entur/antu/security/oauth2/AntuWebSecurityConfiguration.java
@@ -12,7 +12,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -65,31 +64,19 @@ public class AntuWebSecurityConfiguration {
       .csrf(AbstractHttpConfigurer::disable)
       .authorizeHttpRequests(authz ->
         authz
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher(
-              "/services/validation-report/swagger.json"
-            )
-          )
+          .requestMatchers("/services/validation-report/swagger.json")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/services/swagger.json")
-          )
+          .requestMatchers("/services/swagger.json")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/prometheus")
-          )
+          .requestMatchers("/actuator/prometheus")
           .permitAll()
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/health"))
+          .requestMatchers("/actuator/health")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/health/liveness")
-          )
+          .requestMatchers("/actuator/health/liveness")
           .permitAll()
-          .requestMatchers(
-            AntPathRequestMatcher.antMatcher("/actuator/health/readiness")
-          )
+          .requestMatchers("/actuator/health/readiness")
           .permitAll()
-          .requestMatchers(AntPathRequestMatcher.antMatcher("/actuator/info"))
+          .requestMatchers("/actuator/info")
           .permitAll()
           .anyRequest()
           .authenticated()

--- a/src/test/java/no/entur/antu/AntuRouteBuilderIntegrationTestBase.java
+++ b/src/test/java/no/entur/antu/AntuRouteBuilderIntegrationTestBase.java
@@ -50,8 +50,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.PubSubEmulatorContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.gcloud.PubSubEmulatorContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @CamelSpringBootTest
@@ -59,7 +58,6 @@ import org.testcontainers.utility.DockerImageName;
 @ActiveProfiles(
   { "test", "default", "in-memory-blobstore", "google-pubsub-autocreate" }
 )
-@Testcontainers
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public abstract class AntuRouteBuilderIntegrationTestBase {
 

--- a/src/test/java/no/entur/antu/TestApp.java
+++ b/src/test/java/no/entur/antu/TestApp.java
@@ -20,7 +20,7 @@ package no.entur.antu;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 

--- a/src/test/java/no/entur/antu/config/AuthorizationConfigBabaTest.java
+++ b/src/test/java/no/entur/antu/config/AuthorizationConfigBabaTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.entur.antu.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import no.entur.antu.TestApp;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.apache.camel.test.spring.junit5.UseAdviceWith;
+import org.entur.oauth2.JwtRoleAssignmentExtractor;
+import org.entur.ror.permission.RemoteBabaRoleAssignmentExtractor;
+import org.junit.jupiter.api.Test;
+import org.rutebanken.helper.organisation.RoleAssignmentExtractor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Verify the authorization wiring used in all deployed environments, where
+ * antu.security.role.assignment.extractor is set to baba.
+ */
+@CamelSpringBootTest
+@UseAdviceWith
+@ActiveProfiles({ "test", "default", "in-memory-blobstore" })
+@DirtiesContext
+@SpringBootTest(
+  webEnvironment = SpringBootTest.WebEnvironment.NONE,
+  classes = TestApp.class,
+  properties = {
+    "antu.security.role.assignment.extractor=baba",
+    "user.permission.rest.service.url=https://notInUse/services/organisations/users",
+    "ror.oauth2.client.audience=https://notInUse",
+    "spring.cloud.gcp.pubsub.emulator-host=localhost:8085",
+  }
+)
+class AuthorizationConfigBabaTest {
+
+  @Autowired
+  private ApplicationContext applicationContext;
+
+  @Autowired
+  private RoleAssignmentExtractor roleAssignmentExtractor;
+
+  @Test
+  void babaRoleAssignmentExtractorIsTheActiveExtractor() {
+    assertInstanceOf(
+      RemoteBabaRoleAssignmentExtractor.class,
+      roleAssignmentExtractor
+    );
+    assertEquals(
+      0,
+      applicationContext.getBeanNamesForType(JwtRoleAssignmentExtractor.class)
+        .length
+    );
+  }
+
+  @Test
+  void internalWebClientIsCreated() {
+    assertNotNull(
+      applicationContext.getBean("internalWebClient", WebClient.class)
+    );
+  }
+}

--- a/src/test/java/no/entur/antu/config/RedisClientConfigTest.java
+++ b/src/test/java/no/entur/antu/config/RedisClientConfigTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.entur.antu.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.redisson.config.SingleServerConfig;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties;
+
+class RedisClientConfigTest {
+
+  @Test
+  void encryptedRedisConnection(@TempDir Path tempDir) throws Exception {
+    Path trustStore = Files.createFile(tempDir.resolve("redis-truststore.jks"));
+
+    DataRedisProperties redisProperties = new DataRedisProperties();
+    redisProperties.setHost("redis.example.org");
+    redisProperties.setPort(6379);
+
+    SingleServerConfig singleServerConfig = new RedisClientConfig()
+      .redissonConfig(
+        redisProperties,
+        trustStore.toString(),
+        "trustStorePassword",
+        "authenticationString"
+      )
+      .useSingleServer();
+
+    assertEquals(
+      "rediss://redis.example.org:6379",
+      singleServerConfig.getAddress()
+    );
+    assertEquals(
+      trustStore.toUri().toURL().toString(),
+      singleServerConfig.getSslTruststore().toString()
+    );
+    assertEquals(
+      "trustStorePassword",
+      singleServerConfig.getSslTruststorePassword()
+    );
+    assertEquals("authenticationString", singleServerConfig.getPassword());
+  }
+}

--- a/src/test/java/no/entur/antu/config/TestRedisConfiguration.java
+++ b/src/test/java/no/entur/antu/config/TestRedisConfiguration.java
@@ -3,7 +3,7 @@ package no.entur.antu.config;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
-import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
@@ -19,7 +19,7 @@ public class TestRedisConfiguration {
   }
 
   @Bean(initMethod = "start", destroyMethod = "stop")
-  public RedisServer redissonServer(RedisProperties redisProperties) {
+  public RedisServer redissonServer(DataRedisProperties redisProperties) {
     return new RedisServer(redisProperties.getPort());
   }
 }

--- a/src/test/java/no/entur/antu/routes/rest/RestValidationReportRouteBuilderIntegrationTest.java
+++ b/src/test/java/no/entur/antu/routes/rest/RestValidationReportRouteBuilderIntegrationTest.java
@@ -59,7 +59,6 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -111,25 +110,15 @@ class RestValidationReportRouteBuilderIntegrationTest
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authz ->
           authz
-            .requestMatchers(
-              AntPathRequestMatcher.antMatcher("/services/openapi.json")
-            )
+            .requestMatchers("/services/openapi.json")
             .permitAll()
-            .requestMatchers(
-              AntPathRequestMatcher.antMatcher("/actuator/prometheus")
-            )
+            .requestMatchers("/actuator/prometheus")
             .permitAll()
-            .requestMatchers(
-              AntPathRequestMatcher.antMatcher("/actuator/health")
-            )
+            .requestMatchers("/actuator/health")
             .permitAll()
-            .requestMatchers(
-              AntPathRequestMatcher.antMatcher("/actuator/health/liveness")
-            )
+            .requestMatchers("/actuator/health/liveness")
             .permitAll()
-            .requestMatchers(
-              AntPathRequestMatcher.antMatcher("/actuator/health/readiness")
-            )
+            .requestMatchers("/actuator/health/readiness")
             .permitAll()
             .anyRequest()
             .authenticated()

--- a/src/test/java/no/entur/antu/security/oauth2/AntuWebSecurityConfigurationTest.java
+++ b/src/test/java/no/entur/antu/security/oauth2/AntuWebSecurityConfigurationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.entur.antu.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import jakarta.servlet.Filter;
+import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Drives the production security chain built by {@link AntuWebSecurityConfiguration}.
+ * No Spring profile is activated on purpose: the configuration is {@code @Profile("!test")}
+ * and would be skipped under the "test" profile used by the rest of the suite.
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(
+  classes = {
+    AntuWebSecurityConfiguration.class,
+    AntuWebSecurityConfigurationTest.SecurityChainDependencies.class,
+  }
+)
+class AntuWebSecurityConfigurationTest {
+
+  @Configuration
+  static class SecurityChainDependencies {
+
+    @Bean
+    MultiIssuerAuthenticationManagerResolver multiIssuerAuthenticationManagerResolver() {
+      return Mockito.mock(MultiIssuerAuthenticationManagerResolver.class);
+    }
+
+    @Bean
+    ClientRegistrationRepository clientRegistrationRepository() {
+      return registrationId -> null;
+    }
+  }
+
+  @RestController
+  static class AnyPathController {
+
+    @GetMapping("/**")
+    String reached() {
+      return "reached";
+    }
+  }
+
+  @Autowired
+  @Qualifier("springSecurityFilterChain")
+  private Filter springSecurityFilterChain;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc =
+      MockMvcBuilders
+        .standaloneSetup(new AnyPathController())
+        .addFilters(springSecurityFilterChain)
+        .build();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+    strings = {
+      "/services/validation-report/swagger.json",
+      "/services/swagger.json",
+      "/actuator/prometheus",
+      "/actuator/health",
+      "/actuator/health/liveness",
+      "/actuator/health/readiness",
+      "/actuator/info",
+    }
+  )
+  void publicPathIsReachableWithoutAuthentication(String path)
+    throws Exception {
+    assertEquals(
+      200,
+      mockMvc.perform(get(path)).andReturn().getResponse().getStatus(),
+      path + " must be permitted without a token"
+    );
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+    strings = {
+      "/services/validation-report/TST/report-id",
+      "/services/cache-admin/clear-cache",
+      "/actuator",
+      "/actuator/env",
+      "/actuator/health/liveness/extra",
+    }
+  )
+  void otherPathRequiresAuthentication(String path) throws Exception {
+    assertEquals(
+      401,
+      mockMvc.perform(get(path)).andReturn().getResponse().getStatus(),
+      path + " must require a token"
+    );
+  }
+}

--- a/src/test/java/no/entur/antu/validation/validator/interchange/waitingtime/InterchangeWaitingTimeValidatorTest.java
+++ b/src/test/java/no/entur/antu/validation/validator/interchange/waitingtime/InterchangeWaitingTimeValidatorTest.java
@@ -1,7 +1,7 @@
 package no.entur.antu.validation.validator.interchange.waitingtime;
 
 import static no.entur.antu.validation.validator.interchange.waitingtime.InterchangeWaitingTimeValidator.sortedLocalDateTimesForServiceJourneyAtStop;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigInteger;
 import java.time.Duration;
@@ -22,7 +22,6 @@ import org.entur.netex.validation.validator.model.ScheduledStopPointId;
 import org.entur.netex.validation.validator.model.ServiceJourneyId;
 import org.entur.netex.validation.validator.model.ServiceJourneyInterchangeInfo;
 import org.entur.netex.validation.validator.model.ServiceJourneyStop;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.rutebanken.netex.model.*;
@@ -256,10 +255,7 @@ class InterchangeWaitingTimeValidatorTest {
       CODESPACE,
       REFERENCE_TO_NON_EXISTENT_FROM_SERVICE_JOURNEY
     );
-    Assertions.assertEquals(
-      validationReport,
-      validator.validate(validationReport)
-    );
+    assertEquals(validationReport, validator.validate(validationReport));
   }
 
   private void setupTestCaseWithReferenceToNonExistentToServiceJourney() {
@@ -300,10 +296,7 @@ class InterchangeWaitingTimeValidatorTest {
       CODESPACE,
       REFERENCE_TO_NON_EXISTENT_TO_SERVICE_JOURNEY
     );
-    Assertions.assertEquals(
-      validationReport,
-      validator.validate(validationReport)
-    );
+    assertEquals(validationReport, validator.validate(validationReport));
   }
 
   @Test
@@ -393,7 +386,7 @@ class InterchangeWaitingTimeValidatorTest {
           .sorted()
           .toList()
       );
-    assertEquals(null, minimum);
+    assertNull(minimum);
   }
 
   @Test
@@ -442,7 +435,7 @@ class InterchangeWaitingTimeValidatorTest {
         fromStop,
         toStop
       );
-    assertTrue(validationIssue == null);
+    assertNull(validationIssue);
   }
 
   @Test
@@ -476,12 +469,12 @@ class InterchangeWaitingTimeValidatorTest {
         fromStop,
         toStop
       );
-    assertTrue(validationIssue != null);
+    assertNotNull(validationIssue);
     assertEquals(
-      validationIssue.rule().name(),
-      InterchangeWaitingTimeValidator.RULE_SERVICE_JOURNEYS_HAS_TOO_LONG_WAITING_TIME_WARNING.name()
+      InterchangeWaitingTimeValidator.RULE_SERVICE_JOURNEYS_HAS_TOO_LONG_WAITING_TIME_WARNING.name(),
+      validationIssue.rule().name()
     );
-    assertEquals(validationIssue.rule().severity(), Severity.WARNING);
+    assertEquals(Severity.WARNING, validationIssue.rule().severity());
   }
 
   @Test
@@ -515,12 +508,12 @@ class InterchangeWaitingTimeValidatorTest {
         fromStop,
         toStop
       );
-    assertTrue(validationIssue != null);
+    assertNotNull(validationIssue);
     assertEquals(
-      validationIssue.rule().name(),
-      InterchangeWaitingTimeValidator.RULE_NO_INTERCHANGE_POSSIBLE.name()
+      InterchangeWaitingTimeValidator.RULE_NO_INTERCHANGE_POSSIBLE.name(),
+      validationIssue.rule().name()
     );
-    assertEquals(validationIssue.rule().severity(), Severity.WARNING);
+    assertEquals(Severity.WARNING, validationIssue.rule().severity());
   }
 
   @Test


### PR DESCRIPTION
camel-spring-boot 4.18.3 is built against Boot 3.5 and references Boot classes that Boot 4 relocated, so Camel has to move too. 4.21.0 is the release that also keeps the pubsub consumer's in-flight drain.

Boot 4 ships Spring Data 4.0, so redisson-spring-data-40 replaces the starter's default 41.

Java goes to 21; the runtime image was already 21.