### PR TITLE
Gate probes on a platform-http endpoint

### DIFF
--- a/helm/antu/templates/configmap.yaml
+++ b/helm/antu/templates/configmap.yaml
@@ -9,6 +9,9 @@ data:
     # init the servlet before Camel starts, or platform-http's route mappings are unreachable
     # and every /services/** request gets Spring's no-handler 404
     spring.mvc.servlet.load-on-startup=1
+    # platform-http runs every /services/** route on this pool; Boot's default core of 8 with an
+    # unbounded queue never grows, so report downloads can starve the probes off the pool
+    spring.task.execution.pool.core-size=32
 
     # Camel
     camel.main.name=antu

--- a/helm/antu/templates/deployment.yaml
+++ b/helm/antu/templates/deployment.yaml
@@ -65,25 +65,31 @@ spec:
               name: http
               protocol: TCP
           livenessProbe:
+            # also platform-http, so a pod whose Camel mappings never registered is recycled
+            # instead of silently leaving the Service; /actuator/health/liveness cannot see that
             httpGet:
-              path: /actuator/health/liveness
+              path: /services/health
               port: {{ .Values.service.http.internalPort }}
               scheme: HTTP
             initialDelaySeconds: 140
             periodSeconds: 10
             successThreshold: 1
-            failureThreshold: 3
-            timeoutSeconds: 30
+            failureThreshold: 12
+            # must stay below periodSeconds: kubelet does not serialise probes, and each in-flight
+            # probe holds one of platform-http's executor threads
+            timeoutSeconds: 5
           readinessProbe:
+            # served by platform-http, so a pod whose Camel HTTP routes are unreachable fails
+            # readiness instead of serving 404s; /actuator/health/readiness stays UP in that state
             httpGet:
-              path: /actuator/health/readiness
+              path: /services/health
               port: {{ .Values.service.http.internalPort }}
               scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
-            timeoutSeconds: 10
+            timeoutSeconds: 5
           resources:
             limits:
               memory: {{ .Values.resources.memLimit }}

--- a/src/main/java/no/entur/antu/routes/rest/HealthRouteBuilder.java
+++ b/src/main/java/no/entur/antu/routes/rest/HealthRouteBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *   https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ *
+ */
+
+package no.entur.antu.routes.rest;
+
+import no.entur.antu.routes.BaseRouteBuilder;
+import org.apache.camel.Exchange;
+import org.apache.camel.Ordered;
+import org.apache.camel.model.rest.RestBindingMode;
+import org.springframework.stereotype.Component;
+
+/**
+ * Readiness endpoint served by platform-http itself.
+ * The actuator health group reports UP even when the platform-http routes are unreachable and
+ * every /services/** request gets Spring's no-handler 404, so pointing the readiness probe here
+ * is what keeps such a pod out of the Service endpoints. Answers from a constant with no
+ * dependency on Redis, GCS or PubSub, so it never fails on a downstream outage.
+ */
+@Component
+public class HealthRouteBuilder extends BaseRouteBuilder {
+
+  private static final String PLAIN = "text/plain";
+
+  /**
+   * Each builder's rests are converted as that builder is processed, so this one must run after
+   * the builder that declares restConfiguration().
+   */
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST;
+  }
+
+  @Override
+  public void configure() throws Exception {
+    super.configure();
+
+    rest("/health")
+      .apiDocs(false)
+      .get()
+      .bindingMode(RestBindingMode.off)
+      .to("direct:health");
+
+    from("direct:health")
+      .setHeader(Exchange.CONTENT_TYPE, constant(PLAIN))
+      .setBody(constant("OK"))
+      .routeId("health");
+  }
+}

--- a/src/main/java/no/entur/antu/security/oauth2/AntuWebSecurityConfiguration.java
+++ b/src/main/java/no/entur/antu/security/oauth2/AntuWebSecurityConfiguration.java
@@ -7,10 +7,12 @@ import org.entur.oauth2.multiissuer.MultiIssuerAuthenticationManagerResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -62,8 +64,15 @@ public class AntuWebSecurityConfiguration {
     http
       .cors(withDefaults())
       .csrf(AbstractHttpConfigurer::disable)
+      // a JWT resource server has no use for sessions, and without this an unauthenticated 401
+      // mints one per request via the saved-request cache
+      .sessionManagement(session ->
+        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+      )
       .authorizeHttpRequests(authz ->
         authz
+          .requestMatchers(HttpMethod.GET, "/services/health")
+          .permitAll()
           .requestMatchers("/services/validation-report/swagger.json")
           .permitAll()
           .requestMatchers("/services/swagger.json")

--- a/src/test/java/no/entur/antu/routes/rest/RestValidationReportRouteBuilderIntegrationTest.java
+++ b/src/test/java/no/entur/antu/routes/rest/RestValidationReportRouteBuilderIntegrationTest.java
@@ -169,8 +169,32 @@ class RestValidationReportRouteBuilderIntegrationTest
   )
   protected ProducerTemplate validationReportTemplate;
 
+  @Produce("http:localhost:{{server.port}}/services/health")
+  protected ProducerTemplate healthTemplate;
+
   @Value("${server.port}")
   private int serverPort;
+
+  /**
+   * The readiness probe targets this endpoint, so it has to be served by platform-http itself.
+   * The actuator health group reports UP even when the platform-http mappings are unreachable,
+   * which is the failure mode this endpoint exists to expose.
+   */
+  @Test
+  void getHealth() throws Exception {
+    context.start();
+
+    InputStream response = (InputStream) healthTemplate.requestBodyAndHeaders(
+      null,
+      getTestHeaders("GET")
+    );
+
+    assertNotNull(response);
+    assertEquals(
+      "OK",
+      new String(response.readAllBytes(), StandardCharsets.UTF_8)
+    );
+  }
 
   @Test
   void getValidationReport() throws Exception {

--- a/src/test/java/no/entur/antu/security/oauth2/AntuWebSecurityConfigurationTest.java
+++ b/src/test/java/no/entur/antu/security/oauth2/AntuWebSecurityConfigurationTest.java
@@ -95,6 +95,7 @@ class AntuWebSecurityConfigurationTest {
   @ParameterizedTest
   @ValueSource(
     strings = {
+      "/services/health",
       "/services/validation-report/swagger.json",
       "/services/swagger.json",
       "/actuator/prometheus",


### PR DESCRIPTION
/actuator/health reports UP even when Camel's platform-http mappings are unreachable and every /services/** request gets Spring's no-handler 404, so both probes now target GET /services/health, served by Camel itself.

Boot's default task executor (core 8, unbounded queue) never grows past core size and runs every platform-http route, so the pool goes to 32 and probe timeouts stay below periodSeconds.

The chain is stateless and the endpoint permitAll for GET only; an unauthenticated 401 otherwise mints a session per request.