### PR TITLE
jdk 25 and spring boot 4.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v5.6.0
         with:
-          java-version: 21.0.5+11
+          java-version: 25.0.4
           distribution: liberica
       - name: Cache Maven dependencies
         uses: actions/cache@v6.1.0
@@ -50,6 +50,31 @@ jobs:
                   -Dsonar.host.url=https://sonarcloud.io \
                   -Dsonar.token=${SONAR_TOKEN}
 
+  docker-smoke:
+    needs: [ maven-verify ]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/download-artifact@v8.0.1
+        with:
+          name: artifact
+          path: target
+      - run: docker build -t antu:smoke .
+      # Nothing else in CI runs the image. Reaching Spring's startup line proves the JRE accepted the
+      # chart's JVM options and loaded the application bytecode; it then fails on config that only
+      # exists in the cluster, which is fine. Anything earlier (wrong class file version, a flag the
+      # JRE rejects) never gets that far.
+      - run: |
+          opts=$(yq '.jvmFlags' helm/antu/values.yaml | sed 's#-Dspring.config.location=[^ ]*##')
+          # An empty or truncated lift would still let the app log "using Java", so fail loudly here
+          # instead of silently degrading the gate to a flagless run.
+          case "$opts" in *--enable-native-access*) ;; *) echo "::error::could not read jvmFlags"; exit 1 ;; esac
+          timeout 180 docker run --rm -e JDK_JAVA_OPTIONS="$opts" antu:smoke 2>&1 | tee smoke.log || true
+          grep -q "using Java" smoke.log
+
   docker-build:
     if: github.repository_owner == 'entur' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [maven-verify]
@@ -58,5 +83,5 @@ jobs:
       build_artifact_name: artifact
       build_artifact_path: target
   docker-push:
-    needs: [docker-build]
+    needs: [docker-build, docker-smoke]
     uses: entur/gha-docker/.github/workflows/push.yml@v1.11.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM bellsoft/liberica-openjre-alpine:21.0.12 AS builder
+FROM bellsoft/liberica-openjre-alpine:25.0.4 AS builder
 WORKDIR /builder
 COPY target/*-SNAPSHOT.jar application.jar
 RUN java -Djarmode=tools  -jar application.jar extract --layers --destination extracted
 
-FROM bellsoft/liberica-openjre-alpine:21.0.12
+FROM bellsoft/liberica-openjre-alpine:25.0.4
 RUN apk update && apk upgrade && apk add --no-cache tini
 WORKDIR /deployments
 RUN addgroup appuser && adduser --disabled-password appuser --ingroup appuser

--- a/helm/antu/templates/deployment.yaml
+++ b/helm/antu/templates/deployment.yaml
@@ -33,11 +33,8 @@ spec:
           image: {{ .Values.image.identifier }}
           env:
             - name: JDK_JAVA_OPTIONS
-              value: -Xmx{{ .Values.resources.xmx }} -Xms128m -Xss512k -XX:ActiveProcessorCount=2
-                --add-opens=java.base/java.nio=ALL-UNNAMED
-                --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-                -Dspring.config.location=/etc/application-config/application.properties
-                -Dfile.encoding=UTF-8  {{- if .Values.monitoringEnabled}} -Dcom.sun.management.jmxremote.port=9999  -Dcom.sun.management.jmxremote.rmi.port=9998 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1
+              value: -Xmx{{ .Values.resources.xmx }} {{ .Values.jvmFlags }}
+                {{- if .Values.monitoringEnabled}} -Dcom.sun.management.jmxremote.port=9999  -Dcom.sun.management.jmxremote.rmi.port=9998 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1
             {{- end}}
             - name: TZ
               value: Europe/Oslo

--- a/helm/antu/values.yaml
+++ b/helm/antu/values.yaml
@@ -13,6 +13,21 @@ resources:
   memRequest: 3000Mi
   xmx: 2500m
 
+# Static half of JDK_JAVA_OPTIONS; -Xmx comes from resources.xmx and the JMX options from
+# monitoringEnabled. Kept here rather than inline in the deployment so the CI smoke job can read the
+# real option string with yq. --sun-misc-unsafe-memory-access is load-bearing: Kryo's FieldSerializer
+# calls Unsafe.objectFieldOffset, so POJO writes to the Redis caches fail without it.
+# IgnoreUnrecognizedVMOptions keeps the JVM starting if this chart ever meets a pre-JDK-24 image.
+jvmFlags: >-
+  -Xms128m -Xss512k -XX:ActiveProcessorCount=2
+  --add-opens=java.base/java.nio=ALL-UNNAMED
+  --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+  -XX:+IgnoreUnrecognizedVMOptions
+  --enable-native-access=ALL-UNNAMED
+  --sun-misc-unsafe-memory-access=allow
+  -Dspring.config.location=/etc/application-config/application.properties
+  -Dfile.encoding=UTF-8
+
 horizontalPodAutoscaler:
   maxReplicas: 10
   minReplicas: 2

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>6.5.0</version>
+        <version>7.0.0</version>
     </parent>
 
     <groupId>no.entur.antu</groupId>
@@ -23,12 +23,11 @@
         <developerConnection>scm:git:ssh://git@github.com:entur/antu.git</developerConnection>
     </scm>
     <properties>
-        <java.version>21</java.version>
         <camel.version>4.21.0</camel.version>
         <entur.helpers.version>7.2.0</entur.helpers.version>
-        <spring-cloud-gcp-dependencies.version>7.4.10</spring-cloud-gcp-dependencies.version>
+        <spring-cloud-gcp-dependencies.version>8.1.0</spring-cloud-gcp-dependencies.version>
         <!-- unmanaged by any BOM, must track the kubernetes-client version that camel-kubernetes pulls in -->
-        <kubernetes-client.version>7.8.0</kubernetes-client.version>
+        <kubernetes-client.version>7.7.0</kubernetes-client.version>
         <netex-validator-java.version>11.0.31</netex-validator-java.version>
         <netex-parser-java.version>3.1.82</netex-parser-java.version>
         <jts-core.version>1.20.0</jts-core.version>
@@ -50,8 +49,10 @@
         <dependencies>
 
             <!--
-              Must precede spring-cloud-gcp-dependencies, which pins opentelemetry-api to an older
-              version than the rest of the opentelemetry modules resolve to. First declaration wins.
+              Keeps the whole opentelemetry graph on one version when spring-cloud-gcp and Spring Boot
+              disagree on it. First declaration wins, so this pins every module to Boot's
+              opentelemetry.version. Currently a no-op (Boot 4.1.0 and spring-cloud-gcp 8.1.0 both land
+              on 1.62.0); it matters again the next time libraries-bom runs ahead of Boot.
             -->
             <dependency>
                 <groupId>io.opentelemetry</groupId>
@@ -99,6 +100,15 @@
             <groupId>org.entur.ror.helpers</groupId>
             <artifactId>entur-google-pubsub</artifactId>
             <version>${entur.helpers.version}</version>
+            <exclusions>
+                <!-- Build-time library leaked as a compile dependency. spring-boot-dependencies does
+                     not manage it, so it stays at the 4.0.4 that entur-helpers' own parent pins.
+                     Nothing loads it at runtime. -->
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-loader-tools</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.entur.ror.helpers</groupId>
@@ -166,18 +176,6 @@
         <dependency>
             <groupId>org.redisson</groupId>
             <artifactId>redisson-spring-boot-starter</artifactId>
-            <version>${redisson.version}</version>
-            <exclusions>
-                <!-- The starter targets Spring Boot 4.1; swap in the Spring Data Redis 4.0 module -->
-                <exclusion>
-                    <groupId>org.redisson</groupId>
-                    <artifactId>redisson-spring-data-41</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.redisson</groupId>
-            <artifactId>redisson-spring-data-40</artifactId>
             <version>${redisson.version}</version>
         </dependency>
         <!-- Used by Redisson -->


### PR DESCRIPTION
spring-cloud-gcp 8.1.0 is the first release built against Spring Boot 4; 7.4.10 referenced Boot 3 actuator health and bootstrap classes that no longer exist. redisson-spring-data-41 replaces the -40 module now that Boot 4.1 brings spring-data-redis 4.1. Keep kubernetes-client at 7.7.0 to match camel-kubernetes. Static JVM options move to values.yaml so the smoke job can read them with yq.