### PR TITLE
Ignore references to VehicleType, for now. This is to enable plan dat…

### DIFF
--- a/src/main/java/no/entur/antu/config/ValidatorConfig.java
+++ b/src/main/java/no/entur/antu/config/ValidatorConfig.java
@@ -26,6 +26,7 @@ import no.entur.antu.validation.state.ValidationStateRepository;
 import no.entur.antu.validation.validator.id.NetexIdValidator;
 import no.entur.antu.validation.validator.id.ReferenceToNsrValidator;
 import no.entur.antu.validation.validator.id.TrainElementRegistryIdValidator;
+import no.entur.antu.validation.validator.vehicletype.VehicleTypeReferenceIgnorer;
 import org.entur.netex.validation.configuration.DefaultValidationConfigLoader;
 import org.entur.netex.validation.configuration.ValidationConfigLoader;
 import org.entur.netex.validation.validator.DefaultValidationEntryFactory;
@@ -119,6 +120,7 @@ public class ValidatorConfig {
     externalReferenceValidators.add(new BlockJourneyReferencesIgnorer());
     externalReferenceValidators.add(new ServiceJourneyInterchangeIgnorer());
     externalReferenceValidators.add(new InterchangeRuleReferencesIgnorer());
+    externalReferenceValidators.add(new VehicleTypeReferenceIgnorer());
     externalReferenceValidators.add(new TrainElementRegistryIdValidator());
     externalReferenceValidators.add(referenceToNsrValidator);
     return new NetexReferenceValidator(

--- a/src/main/java/no/entur/antu/validation/validator/vehicletype/VehicleTypeReferenceIgnorer.java
+++ b/src/main/java/no/entur/antu/validation/validator/vehicletype/VehicleTypeReferenceIgnorer.java
@@ -15,11 +15,11 @@ public class VehicleTypeReferenceIgnorer implements ExternalReferenceValidator {
     Objects.requireNonNull(externalIdsToValidate);
     return externalIdsToValidate
       .stream()
-      .filter(VehicleTypeReferenceIgnorer::isIgnorableReferenceFromInterchange)
+      .filter(VehicleTypeReferenceIgnorer::isIgnorableVehicleReference)
       .collect(Collectors.toUnmodifiableSet());
   }
 
-  private static boolean isIgnorableReferenceFromInterchange(IdVersion ref) {
+  private static boolean isIgnorableVehicleReference(IdVersion ref) {
     return (
       (
         "VehicleTypeRef".equals(ref.getElementName()) &&

--- a/src/main/java/no/entur/antu/validation/validator/vehicletype/VehicleTypeReferenceIgnorer.java
+++ b/src/main/java/no/entur/antu/validation/validator/vehicletype/VehicleTypeReferenceIgnorer.java
@@ -1,0 +1,34 @@
+package no.entur.antu.validation.validator.vehicletype;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.entur.netex.validation.validator.id.ExternalReferenceValidator;
+import org.entur.netex.validation.validator.id.IdVersion;
+
+public class VehicleTypeReferenceIgnorer implements ExternalReferenceValidator {
+
+  @Override
+  public Set<IdVersion> validateReferenceIds(
+    Set<IdVersion> externalIdsToValidate
+  ) {
+    Objects.requireNonNull(externalIdsToValidate);
+    return externalIdsToValidate
+      .stream()
+      .filter(VehicleTypeReferenceIgnorer::isIgnorableReferenceFromInterchange)
+      .collect(Collectors.toUnmodifiableSet());
+  }
+
+  private static boolean isIgnorableReferenceFromInterchange(IdVersion ref) {
+    return (
+      (
+        "VehicleTypeRef".equals(ref.getElementName()) &&
+        ref.getId().contains("VehicleType")
+      ) ||
+      (
+        "VehicleRef".equals(ref.getElementName()) &&
+        ref.getId().contains("Vehicle")
+      )
+    );
+  }
+}

--- a/src/test/java/no/entur/antu/validation/validator/vehicletype/VehicleTypeIgnorerTest.java
+++ b/src/test/java/no/entur/antu/validation/validator/vehicletype/VehicleTypeIgnorerTest.java
@@ -1,0 +1,80 @@
+package no.entur.antu.validation.validator.vehicletype;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import no.entur.antu.config.ValidatorConfig;
+import no.entur.antu.validation.validator.id.ReferenceToNsrValidator;
+import org.entur.netex.validation.validator.ValidationIssue;
+import org.entur.netex.validation.validator.id.IdVersion;
+import org.entur.netex.validation.validator.id.NetexIdRepository;
+import org.entur.netex.validation.validator.id.NetexReferenceValidator;
+import org.entur.netex.validation.validator.jaxb.StopPlaceRepository;
+import org.entur.netex.validation.validator.xpath.XPathValidationContext;
+import org.entur.netex.validation.xml.NetexXMLParser;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class VehicleTypeIgnorerIntegrationTest {
+
+    @Test
+    void testServiceJourneyWithNonExistentVehicleTypeRefIsAccepted()  {
+        // Create the test NeTEx XML with a ServiceJourney that has a non-existent VehicleTypeRef
+        String netexXml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
+        <dataObjects>
+          <CompositeFrame>
+            <frames>
+              <ServiceFrame>
+                <vehicleJourneys>
+                  <ServiceJourney id="TST:ServiceJourney:1" version="1">
+                    <VehicleTypeRef ref="TST:VehicleType:999"/>
+                  </ServiceJourney>
+                </vehicleJourneys>
+              </ServiceFrame>
+            </frames>
+          </CompositeFrame>
+        </dataObjects>
+      </PublicationDelivery>
+      """;
+
+        // Setup the validator components
+        NetexXMLParser parser = new NetexXMLParser(Set.of("SiteFrame"));
+        NetexIdRepository netexIdRepository = Mockito.mock(NetexIdRepository.class);
+        StopPlaceRepository stopPlaceRepository = Mockito.mock(StopPlaceRepository.class);
+        ReferenceToNsrValidator referenceToNsrValidator = new ReferenceToNsrValidator(stopPlaceRepository);
+
+        ValidatorConfig config = new ValidatorConfig();
+        NetexReferenceValidator validator = config.netexReferenceValidator(
+                netexIdRepository,
+                referenceToNsrValidator
+        );
+
+        // Parse the XML
+        var document = parser.parseByteArrayToXdmNode(netexXml.getBytes());
+        XPathValidationContext context = new XPathValidationContext(
+                document,
+                parser,
+                "TST",
+                null,
+                Set.of(),
+                List.of(new IdVersion("TST:VehicleType:999", null, "VehicleTypeRef", null, "Test.xml", 99, 34)),
+                "reportid-1"
+        );
+
+        // Run validation
+        List<ValidationIssue> issues = validator.validate(context);
+
+        // Assert that VehicleTypeRef does not produce a NETEX_ID_5 error
+        assertFalse(
+                issues.stream()
+                        .anyMatch(issue ->
+                                issue.rule().code().equals("NETEX_ID_5")
+                        ),
+                "VehicleTypeRef should be ignored and not produce NETEX_ID_5 errors"
+        );
+    }
+}

--- a/src/test/java/no/entur/antu/validation/validator/vehicletype/VehicleTypeIgnorerTest.java
+++ b/src/test/java/no/entur/antu/validation/validator/vehicletype/VehicleTypeIgnorerTest.java
@@ -1,8 +1,8 @@
 package no.entur.antu.validation.validator.vehicletype;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import no.entur.antu.config.ValidatorConfig;
@@ -15,7 +15,6 @@ import org.entur.netex.validation.validator.jaxb.StopPlaceRepository;
 import org.entur.netex.validation.validator.xpath.XPathValidationContext;
 import org.entur.netex.validation.xml.NetexXMLParser;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class VehicleTypeIgnorerIntegrationTest {
 
@@ -33,6 +32,7 @@ class VehicleTypeIgnorerIntegrationTest {
                 <vehicleJourneys>
                   <ServiceJourney id="TST:ServiceJourney:1" version="1">
                     <VehicleTypeRef ref="TST:VehicleType:999"/>
+                    <VehicleRef ref="TST:Vehicle:123"/>
                   </ServiceJourney>
                 </vehicleJourneys>
               </ServiceFrame>
@@ -44,10 +44,8 @@ class VehicleTypeIgnorerIntegrationTest {
 
     // Setup the validator components
     NetexXMLParser parser = new NetexXMLParser(Set.of("SiteFrame"));
-    NetexIdRepository netexIdRepository = Mockito.mock(NetexIdRepository.class);
-    StopPlaceRepository stopPlaceRepository = Mockito.mock(
-      StopPlaceRepository.class
-    );
+    NetexIdRepository netexIdRepository = mock(NetexIdRepository.class);
+    StopPlaceRepository stopPlaceRepository = mock(StopPlaceRepository.class);
     ReferenceToNsrValidator referenceToNsrValidator =
       new ReferenceToNsrValidator(stopPlaceRepository);
 
@@ -74,6 +72,15 @@ class VehicleTypeIgnorerIntegrationTest {
           "Test.xml",
           99,
           34
+        ),
+        new IdVersion(
+          "TST:Vehicle:123",
+          null,
+          "VehicleRef",
+          null,
+          "Test.xml",
+          100,
+          24
         )
       ),
       "reportid-1"

--- a/src/test/java/no/entur/antu/validation/validator/vehicletype/VehicleTypeIgnorerTest.java
+++ b/src/test/java/no/entur/antu/validation/validator/vehicletype/VehicleTypeIgnorerTest.java
@@ -19,10 +19,11 @@ import org.mockito.Mockito;
 
 class VehicleTypeIgnorerIntegrationTest {
 
-    @Test
-    void testServiceJourneyWithNonExistentVehicleTypeRefIsAccepted()  {
-        // Create the test NeTEx XML with a ServiceJourney that has a non-existent VehicleTypeRef
-        String netexXml = """
+  @Test
+  void testServiceJourneyWithNonExistentVehicleTypeRefIsAccepted() {
+    // Create the test NeTEx XML with a ServiceJourney that has a non-existent VehicleTypeRef
+    String netexXml =
+      """
       <?xml version="1.0" encoding="UTF-8"?>
       <PublicationDelivery xmlns="http://www.netex.org.uk/netex">
         <dataObjects>
@@ -41,40 +42,52 @@ class VehicleTypeIgnorerIntegrationTest {
       </PublicationDelivery>
       """;
 
-        // Setup the validator components
-        NetexXMLParser parser = new NetexXMLParser(Set.of("SiteFrame"));
-        NetexIdRepository netexIdRepository = Mockito.mock(NetexIdRepository.class);
-        StopPlaceRepository stopPlaceRepository = Mockito.mock(StopPlaceRepository.class);
-        ReferenceToNsrValidator referenceToNsrValidator = new ReferenceToNsrValidator(stopPlaceRepository);
+    // Setup the validator components
+    NetexXMLParser parser = new NetexXMLParser(Set.of("SiteFrame"));
+    NetexIdRepository netexIdRepository = Mockito.mock(NetexIdRepository.class);
+    StopPlaceRepository stopPlaceRepository = Mockito.mock(
+      StopPlaceRepository.class
+    );
+    ReferenceToNsrValidator referenceToNsrValidator =
+      new ReferenceToNsrValidator(stopPlaceRepository);
 
-        ValidatorConfig config = new ValidatorConfig();
-        NetexReferenceValidator validator = config.netexReferenceValidator(
-                netexIdRepository,
-                referenceToNsrValidator
-        );
+    ValidatorConfig config = new ValidatorConfig();
+    NetexReferenceValidator validator = config.netexReferenceValidator(
+      netexIdRepository,
+      referenceToNsrValidator
+    );
 
-        // Parse the XML
-        var document = parser.parseByteArrayToXdmNode(netexXml.getBytes());
-        XPathValidationContext context = new XPathValidationContext(
-                document,
-                parser,
-                "TST",
-                null,
-                Set.of(),
-                List.of(new IdVersion("TST:VehicleType:999", null, "VehicleTypeRef", null, "Test.xml", 99, 34)),
-                "reportid-1"
-        );
+    // Parse the XML
+    var document = parser.parseByteArrayToXdmNode(netexXml.getBytes());
+    XPathValidationContext context = new XPathValidationContext(
+      document,
+      parser,
+      "TST",
+      null,
+      Set.of(),
+      List.of(
+        new IdVersion(
+          "TST:VehicleType:999",
+          null,
+          "VehicleTypeRef",
+          null,
+          "Test.xml",
+          99,
+          34
+        )
+      ),
+      "reportid-1"
+    );
 
-        // Run validation
-        List<ValidationIssue> issues = validator.validate(context);
+    // Run validation
+    List<ValidationIssue> issues = validator.validate(context);
 
-        // Assert that VehicleTypeRef does not produce a NETEX_ID_5 error
-        assertFalse(
-                issues.stream()
-                        .anyMatch(issue ->
-                                issue.rule().code().equals("NETEX_ID_5")
-                        ),
-                "VehicleTypeRef should be ignored and not produce NETEX_ID_5 errors"
-        );
-    }
+    // Assert that VehicleTypeRef does not produce a NETEX_ID_5 error
+    assertFalse(
+      issues
+        .stream()
+        .anyMatch(issue -> issue.rule().code().equals("NETEX_ID_5")),
+      "VehicleTypeRef should be ignored and not produce NETEX_ID_5 errors"
+    );
+  }
 }


### PR DESCRIPTION
…a (ServiceJourney) to contain VehicleTypeRef even if there is currently no validation agains the vehicle registry. That validation will be created later on