### PR TITLE
Follow the stop place export instead of waiting for the cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,13 @@ Mac will need to be restarted for changes to take effect.
 
 ## Access to the stop place registry
 
-Access to the stop place registry is configured in the Spring Boot application.properties file:
+The stop place cache is built from the NeTEx export Tiamat writes to the marduk bucket, and kept current
+by the stop place changelog. Both are configured in the Spring Boot application.properties file:
 
 ```
-antu.stop.registry.id.url=https://tiamat
+antu.netex.stop.current.filename=tiamat/CurrentAndFuture_latest.zip
+antu.stop.refresh.cron=0 */15 * * * *
+org.rutebanken.helper.stopplace.changelog.repository.url=http://tiamat.<env>.entur.internal/services/stop_places
 ```
 
 ## Access to the organization registry

--- a/helm/antu/env/values-kub-ent-tst.yaml
+++ b/helm/antu/env/values-kub-ent-tst.yaml
@@ -65,5 +65,4 @@ ingress:
 horizontalPodAutoscaler:
   project: ent-antu-tst
 
-stopPlaceCacheRefreshCron: 0 0 3,14 * * *
 stopPlaceCacheRefreshQuartzTrigger: ?cron=0+0+03,14+?+*+*

--- a/helm/antu/templates/configmap.yaml
+++ b/helm/antu/templates/configmap.yaml
@@ -64,8 +64,9 @@ data:
     antu.shutdown.drain.timeout.seconds=150
 
     # One thread per @Scheduled method: the leader heartbeat, the two cache refresh triggers, and the
-    # stalled-validation sweep. The last three all do blocking Redis or PubSub work and can coincide, so
-    # anything less than four lets them starve the heartbeat and drop the lease while this pod is healthy.
+    # stalled-validation sweep. The last three all do blocking Redis, PubSub or GCS work and can coincide,
+    # so anything less than four lets them starve the heartbeat and drop the lease while this pod is
+    # healthy.
     spring.task.scheduling.pool.size=4
 
     # Agreement registry
@@ -73,7 +74,7 @@ data:
     antu.agreement.registry.url={{ .Values.agreementRegistryUrl }}
 
     # Stop place dataset import
-    # Refresh stop place cache at 01:00 and 14:00 every day
+    # How often the leader checks the bucket for a new export.
     # Unquoted on purpose: this renders into a properties file, where quotes would become part of
     # the value and the cron parser would reject it at startup.
     antu.stop.refresh.cron={{ .Values.stopPlaceCacheRefreshCron }}

--- a/helm/antu/values.yaml
+++ b/helm/antu/values.yaml
@@ -66,8 +66,14 @@ secrets:
     - KAFKAPASSWORD
     - KAFKAUSERNAME
 
-# Spring cron: second minute hour day-of-month month day-of-week
-stopPlaceCacheRefreshCron: 0 0 1,14 * * *
+# How often the leader checks the bucket for a new stop place export.
+# Spring cron: second minute hour day-of-month month day-of-week.
+#
+# Not the export schedule: Tiamat writes twice a day, and this used to be an hour off it in both
+# directions, which left the cache up to 26 hours behind. A check is one blob metadata read, so the
+# schedule no longer has to guess right. It is also how often a failed refresh is retried, which is
+# why it is not shorter.
+stopPlaceCacheRefreshCron: 0 */15 * * * *
 
 # The same schedule as a quartz trigger URI, for the version being replaced. Delete with the Camel-era
 # ConfigMap keys.

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <developerConnection>scm:git:ssh://git@github.com:entur/antu.git</developerConnection>
     </scm>
     <properties>
-        <entur.helpers.version>7.2.0</entur.helpers.version>
+        <entur.helpers.version>7.3.0</entur.helpers.version>
         <spring-cloud-gcp-dependencies.version>8.1.0</spring-cloud-gcp-dependencies.version>
         <netex-validator-java.version>11.0.31</netex-validator-java.version>
         <netex-parser-java.version>3.1.82</netex-parser-java.version>

--- a/src/main/java/no/entur/antu/config/StopPlaceConfig.java
+++ b/src/main/java/no/entur/antu/config/StopPlaceConfig.java
@@ -22,6 +22,7 @@ import static no.entur.antu.stop.DefaultStopPlaceRepository.STOP_PLACE_CACHE;
 import java.util.Map;
 import no.entur.antu.stop.DefaultStopPlaceRepository;
 import no.entur.antu.stop.DefaultStopPlaceResource;
+import no.entur.antu.stop.StopPlaceDatasetVersionRepository;
 import no.entur.antu.stop.StopPlaceRepositoryLoader;
 import no.entur.antu.stop.changelog.DefaultStopPlaceRepositoryUpdater;
 import no.entur.antu.stop.changelog.StopPlaceRepositoryUpdater;
@@ -30,6 +31,7 @@ import org.entur.netex.validation.validator.model.QuayId;
 import org.entur.netex.validation.validator.model.SimpleQuay;
 import org.entur.netex.validation.validator.model.SimpleStopPlace;
 import org.entur.netex.validation.validator.model.StopPlaceId;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -62,6 +64,13 @@ public class StopPlaceConfig {
       stopPlaceCache,
       quayCache
     );
+  }
+
+  @Bean
+  StopPlaceDatasetVersionRepository stopPlaceDatasetVersionRepository(
+    RedissonClient redissonClient
+  ) {
+    return new StopPlaceDatasetVersionRepository(redissonClient);
   }
 
   @Profile("!stop-place-changelog")

--- a/src/main/java/no/entur/antu/pipeline/StopPlaceCacheRefresher.java
+++ b/src/main/java/no/entur/antu/pipeline/StopPlaceCacheRefresher.java
@@ -4,8 +4,10 @@ import no.entur.antu.job.AntuJob;
 import no.entur.antu.job.JobQueue;
 import no.entur.antu.leader.LeaderElection;
 import no.entur.antu.leader.LeadershipGrantedEvent;
+import no.entur.antu.stop.StopPlaceDatasetVersionRepository;
 import no.entur.antu.stop.StopPlaceRepositoryLoader;
 import no.entur.antu.stop.changelog.StopPlaceRepositoryUpdater;
+import no.entur.antu.stop.loader.StopPlacesDatasetLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
@@ -28,17 +30,23 @@ public class StopPlaceCacheRefresher {
 
   private final StopPlaceRepositoryLoader stopPlaceRepository;
   private final StopPlaceRepositoryUpdater stopPlaceRepositoryUpdater;
+  private final StopPlacesDatasetLoader stopPlacesDatasetLoader;
+  private final StopPlaceDatasetVersionRepository datasetVersionRepository;
   private final LeaderElection leaderElection;
   private final JobQueue jobQueue;
 
   public StopPlaceCacheRefresher(
     StopPlaceRepositoryLoader stopPlaceRepository,
     StopPlaceRepositoryUpdater stopPlaceRepositoryUpdater,
+    StopPlacesDatasetLoader stopPlacesDatasetLoader,
+    StopPlaceDatasetVersionRepository datasetVersionRepository,
     LeaderElection leaderElection,
     JobQueue jobQueue
   ) {
     this.stopPlaceRepository = stopPlaceRepository;
     this.stopPlaceRepositoryUpdater = stopPlaceRepositoryUpdater;
+    this.stopPlacesDatasetLoader = stopPlacesDatasetLoader;
+    this.datasetVersionRepository = datasetVersionRepository;
     this.leaderElection = leaderElection;
     this.jobQueue = jobQueue;
   }
@@ -68,37 +76,91 @@ public class StopPlaceCacheRefresher {
     }
   }
 
+  /**
+   * Queued rather than parsed here: this runs on the thread delivering the leadership event. Queued before
+   * the updater is initialised, so a changelog consumer that cannot start does not cost the cache its only
+   * chance to be filled.
+   *
+   * <p>An empty cache is refreshed whatever the version says, so a cache lost to a flushed or evicted
+   * Redis comes back without waiting for the next export. Only here, not on every check: this runs once
+   * per leadership grant, and a check that ignored the version would queue a parse every tick until the
+   * refresh it queued had finished.
+   */
   private void prime() {
     if (stopPlaceRepository.isEmpty()) {
-      LOGGER.info("Stop place cache is empty, priming cache");
-      stopPlaceRepositoryUpdater.createOrUpdate();
+      LOGGER.info("Stop place cache is empty, queueing a refresh");
+      enqueueRefresh();
     } else {
-      LOGGER.info(
-        "Existing stop place cache found: keep cache and initialize the stop place updater"
-      );
-      stopPlaceRepositoryUpdater.init();
+      queueRefreshIfStale();
     }
+    stopPlaceRepositoryUpdater.init();
   }
 
+  /**
+   * The check is one blob metadata read, so it runs often rather than at an hour that has to match the
+   * export's.
+   */
   @Scheduled(cron = "${antu.stop.refresh.cron:-}")
-  void refreshIfLeader() {
+  void refreshIfDatasetChanged() {
     if (!leaderElection.isLeader()) {
       return;
     }
+    queueRefreshIfStale();
+  }
+
+  /**
+   * A bucket with no dataset at all is left alone, which is an environment nobody has seeded.
+   */
+  private void queueRefreshIfStale() {
+    String version = stopPlacesDatasetLoader.loadDatasetVersion();
+    if (version == null || version.equals(datasetVersionRepository.get())) {
+      return;
+    }
+    LOGGER.info("New stop place dataset {} found in the bucket", version);
     enqueueRefresh();
   }
 
   /**
-   * Put the refresh on the job queue. Also reachable through the cache admin API.
+   * Put the refresh on the job queue. The version is recorded here rather than after the load, so the
+   * checks that fire while the job is queued or running do not queue the same dataset again. Also
+   * reachable through the cache admin API.
+   *
+   * <p>Submitted before the version is recorded, not after. Recording first means a pod that dies between
+   * the Redis write and PubSub confirming the message leaves the export recorded with no job to load it,
+   * and every later check then sees it as loaded: no refresh until the next export lands. This order
+   * fails the other way instead, and the other way is bounded - a job that ran without its version being
+   * recorded is queued once more at the next check.
    */
   public void enqueueRefresh() {
     LOGGER.info("Scheduling stop place cache refresh job");
+    String version = stopPlacesDatasetLoader.loadDatasetVersion();
     jobQueue.submit(new AntuJob.RefreshStopPlaceCache());
+    datasetVersionRepository.set(version);
   }
 
+  /**
+   * A failure is contained rather than thrown. Letting it out nacks the job, and a dataset that cannot be
+   * loaded at all would then redeliver against the pod's one job consumer, each attempt downloading and
+   * parsing the whole export. Clearing the recorded version is the retry instead: the next check sees the
+   * dataset as new again, so a refresh is retried once per check interval rather than as fast as PubSub
+   * can redeliver. The version is read here rather than carried in the job, so what is cleared is
+   * whatever is recorded when this job starts. A newer export recorded before that read is cleared with
+   * it and parsed again at the next check: one redundant parse, not a lost export, and it needs an export
+   * to land in the window between queueing this refresh and starting it.
+   */
   public void refresh() {
     LOGGER.info("Refreshing stop place cache");
-    stopPlaceRepositoryUpdater.createOrUpdate();
-    LOGGER.info("Refreshed stop place cache");
+    String version = datasetVersionRepository.get();
+    try {
+      stopPlaceRepositoryUpdater.createOrUpdate();
+      LOGGER.info("Refreshed stop place cache");
+    } catch (Exception e) {
+      datasetVersionRepository.clearIfStill(version);
+      LOGGER.error(
+        "System error: could not refresh the stop place cache. Validations will report stop places " +
+        "registered since the last import as unresolved references until it succeeds.",
+        e
+      );
+    }
   }
 }

--- a/src/main/java/no/entur/antu/services/MardukBlobStoreService.java
+++ b/src/main/java/no/entur/antu/services/MardukBlobStoreService.java
@@ -18,6 +18,11 @@
 
 package no.entur.antu.services;
 
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import org.rutebanken.helper.storage.repository.BlobStoreRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -28,10 +33,43 @@ import org.springframework.stereotype.Service;
 @Service
 public class MardukBlobStoreService extends AbstractBlobStoreService {
 
+  private static final String UNVERSIONED = "unversioned";
+
+  private final String containerName;
+  private final Optional<Storage> storage;
+
   public MardukBlobStoreService(
     @Value("${blobstore.gcs.marduk.container.name}") String containerName,
-    BlobStoreRepository repository
+    BlobStoreRepository repository,
+    Optional<Storage> storage
   ) {
     super(containerName, repository);
+    this.containerName = containerName;
+    this.storage = storage;
+  }
+
+  /**
+   * A version for a blob that changes when the blob does, or null if the blob is not there. On GCS that is
+   * the generation; a store that keeps no metadata answers with a constant, which is enough to load a
+   * dataset once but not to notice it changing.
+   *
+   * <p>Reads metadata only. {@code getBlob} is not an option for something that is polled:
+   * {@code BlobStoreHelper.getBlobInputStream} downloads the whole object twice, once to check its MD5
+   * and once to hand it over, and the stop place dataset is tens of megabytes.
+   */
+  @Nullable
+  public String blobVersion(String name) {
+    Storage gcs = storage.orElse(null);
+    if (gcs == null) {
+      return existBlob(name) ? UNVERSIONED : null;
+    }
+    Blob blob = gcs.get(
+      BlobId.of(containerName, name),
+      Storage.BlobGetOption.fields(Storage.BlobField.GENERATION)
+    );
+    if (blob == null || blob.getGeneration() == null) {
+      return null;
+    }
+    return Long.toString(blob.getGeneration());
   }
 }

--- a/src/main/java/no/entur/antu/stop/DefaultStopPlaceRepository.java
+++ b/src/main/java/no/entur/antu/stop/DefaultStopPlaceRepository.java
@@ -18,6 +18,7 @@ package no.entur.antu.stop;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
+import no.entur.antu.exception.AntuException;
 import org.entur.netex.validation.validator.model.QuayCoordinates;
 import org.entur.netex.validation.validator.model.QuayId;
 import org.entur.netex.validation.validator.model.SimpleQuay;
@@ -104,31 +105,43 @@ public class DefaultStopPlaceRepository implements StopPlaceRepositoryLoader {
 
   @Override
   public Instant refreshCache() {
+    try {
+      return loadCache();
+    } finally {
+      // The resource holds the parsed dataset, tens of megabytes of it, until this is called. On the way
+      // out of a refusal too, or the pod carries it until the next refresh.
+      stopPlaceResource.clear();
+    }
+  }
+
+  private Instant loadCache() {
     stopPlaceResource.clear();
     Map<StopPlaceId, SimpleStopPlace> newStopPlaceCache =
       stopPlaceResource.getStopPlaces();
+    Map<QuayId, SimpleQuay> newQuayCache = stopPlaceResource.getQuays();
 
-    // TODO: Keep warning logs for testing, remove them later
-    if (newStopPlaceCache.isEmpty()) {
-      LOGGER.warn("Unable to refresh cache, no stop place found");
-    } else {
-      stopPlaceCache.keySet().retainAll(newStopPlaceCache.keySet());
-      stopPlaceCache.putAll(newStopPlaceCache);
+    // The national registry is never empty, so this is a truncated or unparsed export. Refuse it rather
+    // than log and carry on, which leaves the caller believing the cache was refreshed. Checked before
+    // either cache is touched, so the caches keep the export they had rather than pairing new stop
+    // places with the previous quays.
+    if (newStopPlaceCache.isEmpty() || newQuayCache.isEmpty()) {
+      throw new AntuException(
+        "Refusing to refresh the stop place cache from a dataset with %d stop places and %d quays".formatted(
+            newStopPlaceCache.size(),
+            newQuayCache.size()
+          )
+      );
     }
+
+    stopPlaceCache.keySet().retainAll(newStopPlaceCache.keySet());
+    stopPlaceCache.putAll(newStopPlaceCache);
     LOGGER.info("Updated Stop place cache");
 
-    Map<QuayId, SimpleQuay> newQuayCache = stopPlaceResource.getQuays();
-    if (newQuayCache.isEmpty()) {
-      LOGGER.warn("Unable to refresh cache, no quay found");
-    } else {
-      quayCache.keySet().retainAll(newQuayCache.keySet());
-      quayCache.putAll(newQuayCache);
-    }
+    quayCache.keySet().retainAll(newQuayCache.keySet());
+    quayCache.putAll(newQuayCache);
     LOGGER.info("Updated Quay cache");
 
     Instant publicationTime = stopPlaceResource.getPublicationTime();
-
-    stopPlaceResource.clear();
 
     LOGGER.info(
       "Updated cache with " +

--- a/src/main/java/no/entur/antu/stop/StopPlaceDatasetVersionRepository.java
+++ b/src/main/java/no/entur/antu/stop/StopPlaceDatasetVersionRepository.java
@@ -1,0 +1,57 @@
+package no.entur.antu.stop;
+
+import javax.annotation.Nullable;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+
+/**
+ * The version of the stop place dataset the cache was last built from. Shared between pods, because the
+ * pod that decides a refresh is due is not the pod that runs it.
+ */
+public class StopPlaceDatasetVersionRepository {
+
+  private static final String STOP_PLACE_DATASET_VERSION =
+    "stopPlaceDatasetVersion";
+
+  private final RedissonClient redissonClient;
+
+  public StopPlaceDatasetVersionRepository(RedissonClient redissonClient) {
+    this.redissonClient = redissonClient;
+  }
+
+  @Nullable
+  public String get() {
+    return version().get();
+  }
+
+  public void set(@Nullable String datasetVersion) {
+    if (datasetVersion == null) {
+      return;
+    }
+    version().set(datasetVersion);
+  }
+
+  /**
+   * Clear the recorded version, but only while it is still the one given. A caller rolling back its own
+   * write must not erase a newer export another pod recorded in the meantime.
+   */
+  public void clearIfStill(@Nullable String datasetVersion) {
+    if (datasetVersion == null) {
+      return;
+    }
+    version().compareAndSet(datasetVersion, null);
+  }
+
+  /**
+   * Plain strings, not the client's Kryo codec: this is the state an operator reaches for when the cache
+   * looks wrong, and a generation that reads back as {@code \x03175...} from redis-cli does not compare
+   * with what gcloud prints.
+   */
+  private RBucket<String> version() {
+    return redissonClient.getBucket(
+      STOP_PLACE_DATASET_VERSION,
+      StringCodec.INSTANCE
+    );
+  }
+}

--- a/src/main/java/no/entur/antu/stop/changelog/ChangelogStopPlaceRepositoryUpdater.java
+++ b/src/main/java/no/entur/antu/stop/changelog/ChangelogStopPlaceRepositoryUpdater.java
@@ -44,8 +44,15 @@ public class ChangelogStopPlaceRepositoryUpdater
     this.handler = handler;
   }
 
+  /**
+   * Synchronized against {@link #createOrUpdate()}, which is only a same-pod guard: the two run on
+   * different threads of one pod when a refresh job lands on the pod that is taking over as leader, and
+   * starting the consumer while the refresh has its listener unregistered drops every change it reads.
+   * Refresh jobs run on an arbitrary pod, so the cross-pod case is not covered by this and needs a
+   * distributed lock or a leader-local refresh.
+   */
   @Override
-  public void init() {
+  public synchronized void init() {
     LOGGER.info("Initializing Changelog Stop Place Repository Updater");
     Instant timestamp = changelogUpdateTimestampRepository.getTimestamp();
     if (timestamp == null) {
@@ -60,14 +67,42 @@ public class ChangelogStopPlaceRepositoryUpdater
     );
   }
 
+  /**
+   * The consumer comes back whether or not the refresh worked: a refresh that throws would otherwise leave
+   * it stopped with its listener unregistered until the next refresh or the next leader.
+   *
+   * <p>A restart failure is not swallowed. Returning normally tells the refresher the cache was rebuilt,
+   * which keeps the recorded version and stops the checks from retrying, so a transient Kafka failure
+   * would leave the changelog dead until the next export. When the refresh failed too, that exception is
+   * the one that propagates and the restart failure rides along as suppressed.
+   */
   @Override
-  public void createOrUpdate() {
-    changelogConsumerController.stop();
-    stopPlaceChangelog.unregisterStopPlaceChangelogListener(handler);
-    Instant publicationTime = stopPlaceRepositoryLoader.refreshCache();
-    changelogUpdateTimestampRepository.setTimestamp(publicationTime);
-    antuPublicationTimeRecordFilterStrategy.setPublicationTime(publicationTime);
-    stopPlaceChangelog.registerStopPlaceChangelogListener(handler);
-    changelogConsumerController.start();
+  public synchronized void createOrUpdate() {
+    RuntimeException refreshFailure = null;
+    try {
+      changelogConsumerController.stop();
+      stopPlaceChangelog.unregisterStopPlaceChangelogListener(handler);
+      Instant publicationTime = stopPlaceRepositoryLoader.refreshCache();
+      changelogUpdateTimestampRepository.setTimestamp(publicationTime);
+      antuPublicationTimeRecordFilterStrategy.setPublicationTime(
+        publicationTime
+      );
+    } catch (RuntimeException e) {
+      refreshFailure = e;
+    }
+
+    try {
+      stopPlaceChangelog.registerStopPlaceChangelogListener(handler);
+      changelogConsumerController.start();
+    } catch (RuntimeException e) {
+      if (refreshFailure == null) {
+        throw e;
+      }
+      refreshFailure.addSuppressed(e);
+    }
+
+    if (refreshFailure != null) {
+      throw refreshFailure;
+    }
   }
 }

--- a/src/main/java/no/entur/antu/stop/loader/DefaultStopPlacesDatasetLoader.java
+++ b/src/main/java/no/entur/antu/stop/loader/DefaultStopPlacesDatasetLoader.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import javax.annotation.Nullable;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -53,6 +54,12 @@ public class DefaultStopPlacesDatasetLoader implements StopPlacesDatasetLoader {
         e
       );
     }
+  }
+
+  @Override
+  @Nullable
+  public String loadDatasetVersion() {
+    return mardukBlobStoreService.blobVersion(currentStopPlacesFile);
   }
 
   /**

--- a/src/main/java/no/entur/antu/stop/loader/StopPlacesDatasetLoader.java
+++ b/src/main/java/no/entur/antu/stop/loader/StopPlacesDatasetLoader.java
@@ -1,5 +1,6 @@
 package no.entur.antu.stop.loader;
 
+import javax.annotation.Nullable;
 import org.entur.netex.index.api.NetexEntitiesIndex;
 
 /**
@@ -10,4 +11,13 @@ public interface StopPlacesDatasetLoader {
    *  Return an index over JAXB entities extracted from a NeTEx dataset.
    */
   NetexEntitiesIndex loadNetexEntitiesIndex();
+
+  /**
+   * Return an identifier for the dataset now in the bucket, or null if there is none or the store cannot
+   * tell. Cheap enough to poll: it reads the blob's metadata, not the dataset.
+   */
+  @Nullable
+  default String loadDatasetVersion() {
+    return null;
+  }
 }

--- a/src/test/java/no/entur/antu/pipeline/StopPlaceCacheRefresherTest.java
+++ b/src/test/java/no/entur/antu/pipeline/StopPlaceCacheRefresherTest.java
@@ -1,24 +1,36 @@
 package no.entur.antu.pipeline;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import no.entur.antu.job.AntuJob;
 import no.entur.antu.job.JobQueue;
 import no.entur.antu.leader.LeaderElection;
 import no.entur.antu.leader.LeadershipGrantedEvent;
+import no.entur.antu.stop.StopPlaceDatasetVersionRepository;
 import no.entur.antu.stop.StopPlaceRepositoryLoader;
 import no.entur.antu.stop.changelog.StopPlaceRepositoryUpdater;
+import no.entur.antu.stop.loader.StopPlacesDatasetLoader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 class StopPlaceCacheRefresherTest {
 
+  private static final String DATASET = "1787306879708878";
+
   private StopPlaceRepositoryLoader stopPlaceRepository;
   private StopPlaceRepositoryUpdater stopPlaceRepositoryUpdater;
+  private StopPlacesDatasetLoader stopPlacesDatasetLoader;
+  private StopPlaceDatasetVersionRepository datasetVersionRepository;
   private LeaderElection leaderElection;
   private JobQueue jobQueue;
   private StopPlaceCacheRefresher refresher;
@@ -27,75 +39,184 @@ class StopPlaceCacheRefresherTest {
   void setUp() {
     stopPlaceRepository = mock(StopPlaceRepositoryLoader.class);
     stopPlaceRepositoryUpdater = mock(StopPlaceRepositoryUpdater.class);
+    stopPlacesDatasetLoader = mock(StopPlacesDatasetLoader.class);
+    datasetVersionRepository = mock(StopPlaceDatasetVersionRepository.class);
     leaderElection = mock(LeaderElection.class);
     jobQueue = mock(JobQueue.class);
     refresher =
       new StopPlaceCacheRefresher(
         stopPlaceRepository,
         stopPlaceRepositoryUpdater,
+        stopPlacesDatasetLoader,
+        datasetVersionRepository,
         leaderElection,
         jobQueue
       );
   }
 
+  /**
+   * A cache lost to a flushed or evicted Redis has to come back without waiting for the next export, so
+   * this ignores the recorded version.
+   */
   @Test
-  void aColdCacheIsFilledOnTakingOverAsLeader() {
+  void aColdCacheIsQueuedForRefreshOnTakingOverAsLeader() {
     when(stopPlaceRepository.isEmpty()).thenReturn(true);
+    when(stopPlacesDatasetLoader.loadDatasetVersion()).thenReturn(DATASET);
+    when(datasetVersionRepository.get()).thenReturn(DATASET);
 
     refresher.onLeadershipGranted(new LeadershipGrantedEvent());
 
-    verify(stopPlaceRepositoryUpdater).createOrUpdate();
-    verifyNoInteractions(jobQueue);
+    verify(jobQueue).submit(new AntuJob.RefreshStopPlaceCache());
+    verify(stopPlaceRepositoryUpdater, never()).createOrUpdate();
+    verify(stopPlaceRepositoryUpdater).init();
   }
 
   @Test
   void anExistingCacheIsKeptAndTheUpdaterInitialised() {
     when(stopPlaceRepository.isEmpty()).thenReturn(false);
+    when(stopPlacesDatasetLoader.loadDatasetVersion()).thenReturn(DATASET);
+    when(datasetVersionRepository.get()).thenReturn(DATASET);
 
     refresher.onLeadershipGranted(new LeadershipGrantedEvent());
 
     verify(stopPlaceRepositoryUpdater).init();
-  }
-
-  /**
-   * A failed prime must not queue a retry: a permanent failure would redeliver until the subscription's
-   * retention runs out, and there is no dead-letter topic. Recovery is the scheduled refresh, and the
-   * operator is told through the log metric.
-   */
-  @Test
-  void aFailedPrimeDoesNotQueueARetry() {
-    when(stopPlaceRepository.isEmpty()).thenReturn(true);
-    doThrow(new NullPointerException("stop dataset not in the bucket yet"))
-      .when(stopPlaceRepositoryUpdater)
-      .createOrUpdate();
-
-    refresher.onLeadershipGranted(new LeadershipGrantedEvent());
-
     verifyNoInteractions(jobQueue);
   }
 
   /**
-   * The exception must not escape: the event is multicast to both cache primers, and one throwing would
-   * abandon the other, which is only ever published once.
+   * A cold cache is filled by the queued refresh, so an updater that cannot start must not take the
+   * refresh with it.
    */
   @Test
-  void aFailedPrimeDoesNotEscapeTheListener() {
+  void aColdCacheIsQueuedEvenIfTheUpdaterCannotBeInitialised() {
     when(stopPlaceRepository.isEmpty()).thenReturn(true);
-    doThrow(new IllegalStateException("boom"))
+    when(stopPlacesDatasetLoader.loadDatasetVersion()).thenReturn(DATASET);
+    doThrow(new IllegalStateException("no kafka"))
       .when(stopPlaceRepositoryUpdater)
-      .createOrUpdate();
+      .init();
 
     assertDoesNotThrow(() ->
       refresher.onLeadershipGranted(new LeadershipGrantedEvent())
     );
+
+    verify(jobQueue).submit(new AntuJob.RefreshStopPlaceCache());
+  }
+
+  /**
+   * An existing cache with a newer export in the bucket picks it up on taking over, rather than waiting
+   * for the next check.
+   */
+  @Test
+  void aNewDatasetIsQueuedOnTakingOverAsLeader() {
+    when(stopPlaceRepository.isEmpty()).thenReturn(false);
+    when(stopPlacesDatasetLoader.loadDatasetVersion()).thenReturn(DATASET);
+    when(datasetVersionRepository.get()).thenReturn("an-older-generation");
+
+    refresher.onLeadershipGranted(new LeadershipGrantedEvent());
+
+    verify(jobQueue).submit(new AntuJob.RefreshStopPlaceCache());
   }
 
   @Test
   void onlyTheLeaderDecidesWhenToRefresh() {
     when(leaderElection.isLeader()).thenReturn(false);
 
-    refresher.refreshIfLeader();
+    refresher.refreshIfDatasetChanged();
 
     verifyNoInteractions(jobQueue);
+    verifyNoInteractions(stopPlacesDatasetLoader);
+    verifyNoInteractions(stopPlaceRepositoryUpdater);
+  }
+
+  @Test
+  void aNewDatasetInTheBucketIsRefreshed() {
+    leaderSees(DATASET, "an-older-generation");
+
+    refresher.refreshIfDatasetChanged();
+
+    verify(jobQueue).submit(new AntuJob.RefreshStopPlaceCache());
+  }
+
+  @Test
+  void theDatasetTheCacheWasBuiltFromIsNotRefreshedAgain() {
+    leaderSees(DATASET, DATASET);
+
+    refresher.refreshIfDatasetChanged();
+
+    verifyNoInteractions(jobQueue);
+  }
+
+  @Test
+  void aMissingDatasetIsNotRefreshed() {
+    leaderSees(null, null);
+
+    refresher.refreshIfDatasetChanged();
+
+    verifyNoInteractions(jobQueue);
+  }
+
+  /**
+   * Recorded once the job is queued, not before: a pod dying between the Redis write and PubSub confirming
+   * the message would otherwise leave the export recorded with no job to load it, and every later check
+   * would see it as loaded.
+   */
+  @Test
+  void theDatasetIsRecordedAfterTheJobIsQueued() {
+    leaderSees(DATASET, "an-older-generation");
+
+    refresher.refreshIfDatasetChanged();
+
+    InOrder inOrder = inOrder(jobQueue, datasetVersionRepository);
+    inOrder.verify(jobQueue).submit(new AntuJob.RefreshStopPlaceCache());
+    inOrder.verify(datasetVersionRepository).set(DATASET);
+  }
+
+  /**
+   * A failed refresh is contained: letting it out nacks the job, and a dataset that cannot be loaded at
+   * all would redeliver against the pod's one job consumer, parsing the whole export each time. Clearing
+   * the recorded version is the retry, at the next check rather than at PubSub's redelivery rate.
+   */
+  @Test
+  void aFailedRefreshIsContainedAndClearsTheRecordedVersion() {
+    when(datasetVersionRepository.get()).thenReturn(DATASET);
+    doThrow(new IllegalStateException("boom"))
+      .when(stopPlaceRepositoryUpdater)
+      .createOrUpdate();
+
+    assertDoesNotThrow(() -> refresher.refresh());
+
+    verify(datasetVersionRepository).clearIfStill(DATASET);
+  }
+
+  @Test
+  void aSuccessfulRefreshKeepsTheRecordedVersion() {
+    refresher.refresh();
+
+    verify(stopPlaceRepositoryUpdater).createOrUpdate();
+    verify(datasetVersionRepository, never()).clearIfStill(anyString());
+  }
+
+  /**
+   * A submit that never reached PubSub must leave nothing recorded, so the next check retries it.
+   */
+  @Test
+  void aDatasetWhoseJobCouldNotBeQueuedIsNotRecorded() {
+    leaderSees(DATASET, "an-older-generation");
+    doThrow(new IllegalStateException("pubsub is down"))
+      .when(jobQueue)
+      .submit(new AntuJob.RefreshStopPlaceCache());
+
+    assertThrows(
+      IllegalStateException.class,
+      () -> refresher.refreshIfDatasetChanged()
+    );
+
+    verify(datasetVersionRepository, never()).set(anyString());
+  }
+
+  private void leaderSees(String inBucket, String recorded) {
+    when(leaderElection.isLeader()).thenReturn(true);
+    when(stopPlacesDatasetLoader.loadDatasetVersion()).thenReturn(inBucket);
+    when(datasetVersionRepository.get()).thenReturn(recorded);
   }
 }

--- a/src/test/java/no/entur/antu/services/MardukBlobStoreServiceTest.java
+++ b/src/test/java/no/entur/antu/services/MardukBlobStoreServiceTest.java
@@ -1,0 +1,77 @@
+package no.entur.antu.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.rutebanken.helper.storage.repository.InMemoryBlobStoreRepository;
+
+/**
+ * The version has to come from the blob's metadata. Reading it through {@code getBlob} would download the
+ * whole stop place dataset, twice, on every poll.
+ */
+class MardukBlobStoreServiceTest {
+
+  private static final String DATASET = "tiamat/CurrentAndFuture_latest.zip";
+  private static final BlobId BLOB_ID = BlobId.of("marduk", DATASET);
+  private static final Storage.BlobGetOption GENERATION_ONLY =
+    Storage.BlobGetOption.fields(Storage.BlobField.GENERATION);
+
+  @Test
+  void theVersionIsTheBlobGeneration() {
+    Storage storage = mock(Storage.class);
+    Blob blob = mock(Blob.class);
+    when(blob.getGeneration()).thenReturn(1787306879708878L);
+    when(storage.get(eq(BLOB_ID), eq(GENERATION_ONLY))).thenReturn(blob);
+
+    assertEquals("1787306879708878", service(storage).blobVersion(DATASET));
+  }
+
+  @Test
+  void aBlobThatIsNotThereHasNoVersion() {
+    Storage storage = mock(Storage.class);
+    when(storage.get(eq(BLOB_ID), eq(GENERATION_ONLY))).thenReturn(null);
+
+    assertNull(service(storage).blobVersion(DATASET));
+  }
+
+  /**
+   * The in-memory and local-disk stores keep no metadata. They still have to answer that the dataset is
+   * there, or it is never loaded at all; a constant is enough for that, and the price is not noticing the
+   * file change afterwards.
+   */
+  @Test
+  void aStoreThatCannotVersionStillReportsThatTheBlobIsThere() {
+    MardukBlobStoreService service = serviceWithoutGcs();
+    assertNull(service.blobVersion(DATASET));
+
+    service.uploadBlob(DATASET, new ByteArrayInputStream(new byte[] { 1 }));
+
+    assertEquals("unversioned", service.blobVersion(DATASET));
+  }
+
+  private static MardukBlobStoreService serviceWithoutGcs() {
+    return new MardukBlobStoreService(
+      "marduk",
+      new InMemoryBlobStoreRepository(new HashMap<>()),
+      Optional.empty()
+    );
+  }
+
+  private static MardukBlobStoreService service(Storage storage) {
+    return new MardukBlobStoreService(
+      "marduk",
+      new InMemoryBlobStoreRepository(new HashMap<>()),
+      Optional.of(storage)
+    );
+  }
+}

--- a/src/test/java/no/entur/antu/stop/DefaultStopPlaceRepositoryRefreshTest.java
+++ b/src/test/java/no/entur/antu/stop/DefaultStopPlaceRepositoryRefreshTest.java
@@ -1,0 +1,111 @@
+package no.entur.antu.stop;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import no.entur.antu.exception.AntuException;
+import org.entur.netex.validation.validator.model.QuayCoordinates;
+import org.entur.netex.validation.validator.model.QuayId;
+import org.entur.netex.validation.validator.model.SimpleQuay;
+import org.entur.netex.validation.validator.model.SimpleStopPlace;
+import org.entur.netex.validation.validator.model.StopPlaceId;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The national registry is never empty, so a dataset that yields nothing is a truncated or unparsed
+ * export. It has to fail rather than log and return, which leaves the caller believing the cache was
+ * refreshed.
+ */
+class DefaultStopPlaceRepositoryRefreshTest {
+
+  private static final StopPlaceId STOP_PLACE_ID = new StopPlaceId(
+    "NSR:StopPlace:1"
+  );
+  private static final QuayId QUAY_ID = new QuayId("NSR:Quay:1");
+
+  private final Map<StopPlaceId, SimpleStopPlace> stopPlaceCache =
+    new HashMap<>();
+  private final Map<QuayId, SimpleQuay> quayCache = new HashMap<>();
+
+  @Test
+  void aDatasetWithStopPlacesAndQuaysIsLoaded() {
+    DefaultStopPlaceRepository repository = repository(
+      Map.of(STOP_PLACE_ID, new SimpleStopPlace("Jektevik terminal", null)),
+      Map.of(
+        QUAY_ID,
+        new SimpleQuay(new QuayCoordinates(5.3, 60.3), STOP_PLACE_ID)
+      )
+    );
+
+    repository.refreshCache();
+
+    assertEquals(1, stopPlaceCache.size());
+    assertEquals(1, quayCache.size());
+  }
+
+  @Test
+  void aDatasetWithNoStopPlacesIsRefused() {
+    DefaultStopPlaceRepository repository = repository(Map.of(), Map.of());
+
+    assertThrows(AntuException.class, repository::refreshCache);
+  }
+
+  /**
+   * Both halves are checked before either cache is touched: a half-applied refresh would pair the new
+   * export's stop places with the previous one's quays, and the quays whose stop place the refresh dropped
+   * have nothing to resolve against.
+   */
+  @Test
+  void aDatasetWithNoQuaysIsRefusedAndChangesNothing() {
+    StopPlaceId loadedEarlier = new StopPlaceId("NSR:StopPlace:2");
+    stopPlaceCache.put(loadedEarlier, new SimpleStopPlace("Sandvika", null));
+    quayCache.put(
+      QUAY_ID,
+      new SimpleQuay(new QuayCoordinates(5.3, 60.3), loadedEarlier)
+    );
+    DefaultStopPlaceRepository repository = repository(
+      Map.of(STOP_PLACE_ID, new SimpleStopPlace("Jektevik terminal", null)),
+      Map.of()
+    );
+
+    assertThrows(AntuException.class, repository::refreshCache);
+
+    assertEquals(
+      Map.of(loadedEarlier, new SimpleStopPlace("Sandvika", null)),
+      stopPlaceCache
+    );
+    assertEquals(1, quayCache.size());
+  }
+
+  private DefaultStopPlaceRepository repository(
+    Map<StopPlaceId, SimpleStopPlace> stopPlaces,
+    Map<QuayId, SimpleQuay> quays
+  ) {
+    return new DefaultStopPlaceRepository(
+      new StopPlaceResource() {
+        @Override
+        public Map<QuayId, SimpleQuay> getQuays() {
+          return quays;
+        }
+
+        @Override
+        public Map<StopPlaceId, SimpleStopPlace> getStopPlaces() {
+          return stopPlaces;
+        }
+
+        @Override
+        public Instant getPublicationTime() {
+          return Instant.EPOCH;
+        }
+
+        @Override
+        public void clear() {}
+      },
+      stopPlaceCache,
+      quayCache
+    );
+  }
+}

--- a/src/test/java/no/entur/antu/stop/StopPlaceDatasetVersionRepositoryTest.java
+++ b/src/test/java/no/entur/antu/stop/StopPlaceDatasetVersionRepositoryTest.java
@@ -1,0 +1,78 @@
+package no.entur.antu.stop;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import no.entur.antu.config.EmbeddedRedisTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RBucket;
+import org.redisson.client.codec.StringCodec;
+
+class StopPlaceDatasetVersionRepositoryTest extends EmbeddedRedisTestBase {
+
+  private static final String GENERATION = "1787306879708878";
+  private static final String NEWER_GENERATION = "1787306879708879";
+
+  private StopPlaceDatasetVersionRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = new StopPlaceDatasetVersionRepository(redissonClient);
+    bucket().delete();
+  }
+
+  @Test
+  void theVersionSurvivesForTheNextPodToRead() {
+    repository.set(GENERATION);
+
+    assertEquals(GENERATION, repository.get());
+  }
+
+  /**
+   * Stored as a plain string, so that an operator debugging the cache can compare what redis-cli prints
+   * with the generation gcloud reports.
+   */
+  @Test
+  void theVersionIsReadableOutsideTheClient() {
+    repository.set(GENERATION);
+
+    assertEquals(GENERATION, bucket().get());
+  }
+
+  @Test
+  void clearingLetsTheNextCheckSeeTheDatasetAsNew() {
+    repository.set(GENERATION);
+
+    repository.clearIfStill(GENERATION);
+
+    assertNull(repository.get());
+  }
+
+  /**
+   * A caller rolling back its own write must not erase a newer export another pod recorded while it was
+   * on its way: that one would then never be loaded.
+   */
+  @Test
+  void aNewerVersionIsNotCleared() {
+    repository.set(NEWER_GENERATION);
+
+    repository.clearIfStill(GENERATION);
+
+    assertEquals(NEWER_GENERATION, repository.get());
+  }
+
+  @Test
+  void clearingAnUnrecordedVersionIsHarmless() {
+    repository.clearIfStill(GENERATION);
+
+    assertNull(repository.get());
+  }
+
+  private RBucket<String> bucket() {
+    return redissonClient.getBucket(
+      "stopPlaceDatasetVersion",
+      StringCodec.INSTANCE
+    );
+  }
+}

--- a/src/test/java/no/entur/antu/stop/changelog/ChangelogStopPlaceRepositoryUpdaterTest.java
+++ b/src/test/java/no/entur/antu/stop/changelog/ChangelogStopPlaceRepositoryUpdaterTest.java
@@ -1,0 +1,141 @@
+package no.entur.antu.stop.changelog;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import no.entur.antu.stop.StopPlaceRepositoryLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.rutebanken.helper.stopplace.changelog.StopPlaceChangelog;
+import org.rutebanken.helper.stopplace.changelog.kafka.ChangelogConsumerController;
+
+class ChangelogStopPlaceRepositoryUpdaterTest {
+
+  private StopPlaceRepositoryLoader stopPlaceRepositoryLoader;
+  private ChangelogConsumerController changelogConsumerController;
+  private StopPlaceChangelog stopPlaceChangelog;
+  private AntuStopPlaceChangeLogListener handler;
+  private ChangelogStopPlaceRepositoryUpdater updater;
+
+  @BeforeEach
+  void setUp() {
+    stopPlaceRepositoryLoader = mock(StopPlaceRepositoryLoader.class);
+    changelogConsumerController = mock(ChangelogConsumerController.class);
+    stopPlaceChangelog = mock(StopPlaceChangelog.class);
+    handler = mock(AntuStopPlaceChangeLogListener.class);
+    updater =
+      new ChangelogStopPlaceRepositoryUpdater(
+        stopPlaceRepositoryLoader,
+        mock(AntuPublicationTimeRecordFilterStrategy.class),
+        mock(RedisChangelogUpdateTimestampRepository.class),
+        changelogConsumerController,
+        stopPlaceChangelog,
+        handler
+      );
+  }
+
+  /**
+   * A refresh that throws must not leave the consumer stopped with its listener unregistered: it would
+   * stay that way until the next refresh or the next leader.
+   */
+  @Test
+  void aFailedRefreshStillLeavesTheConsumerRunning() {
+    when(stopPlaceRepositoryLoader.refreshCache())
+      .thenThrow(new IllegalStateException("no stop places in the dataset"));
+
+    assertThrows(IllegalStateException.class, () -> updater.createOrUpdate());
+
+    verify(stopPlaceChangelog).registerStopPlaceChangelogListener(handler);
+    verify(changelogConsumerController).start();
+  }
+
+  /**
+   * A refresh stops the consumer and unregisters the listener while it parses the dataset, and a pod
+   * taking over as leader initialises the updater on another thread. Registering and starting inside that
+   * window would consume changes with no listener registered, and they would not be seen again until the
+   * container next restarts. Run this against an updater without the synchronized: init runs to completion
+   * instead of blocking, which is the only thing that makes it a test of the fix.
+   */
+  @Test
+  void initWaitsForARefreshToPutTheConsumerBack() throws Exception {
+    CountDownLatch refreshStarted = new CountDownLatch(1);
+    CountDownLatch letRefreshFinish = new CountDownLatch(1);
+    CountDownLatch initReturned = new CountDownLatch(1);
+    when(stopPlaceRepositoryLoader.refreshCache())
+      .thenAnswer(invocation -> {
+        refreshStarted.countDown();
+        assertTrue(letRefreshFinish.await(5, TimeUnit.SECONDS));
+        return Instant.now();
+      });
+
+    Thread refresh = new Thread(updater::createOrUpdate);
+    refresh.start();
+    assertTrue(refreshStarted.await(5, TimeUnit.SECONDS));
+
+    Thread takeOverAsLeader = new Thread(() -> {
+      updater.init();
+      initReturned.countDown();
+    });
+    takeOverAsLeader.start();
+
+    await()
+      .atMost(Duration.ofSeconds(5))
+      .until(() -> takeOverAsLeader.getState() == Thread.State.BLOCKED);
+    assertFalse(initReturned.getCount() == 0);
+    verify(changelogConsumerController, never()).start();
+
+    letRefreshFinish.countDown();
+    refresh.join(TimeUnit.SECONDS.toMillis(5));
+    assertTrue(initReturned.await(5, TimeUnit.SECONDS));
+    assertFalse(refresh.isAlive());
+    verify(changelogConsumerController, times(2)).start();
+  }
+
+  /**
+   * A restart failure must not make the refresh look successful: the refresher would keep the recorded
+   * version and no check would retry, leaving the changelog dead until the next export.
+   */
+  @Test
+  void aConsumerThatCannotBeRestartedFailsTheRefresh() {
+    when(stopPlaceRepositoryLoader.refreshCache()).thenReturn(Instant.now());
+    doThrow(new IllegalStateException("kafka is down"))
+      .when(changelogConsumerController)
+      .start();
+
+    assertThrows(IllegalStateException.class, () -> updater.createOrUpdate());
+  }
+
+  /**
+   * When both fail the refresh failure is the one that propagates, so the log names the real cause.
+   */
+  @Test
+  void aFailedRefreshOutranksAFailedRestart() {
+    doThrow(new IllegalStateException("bad export"))
+      .when(stopPlaceRepositoryLoader)
+      .refreshCache();
+    doThrow(new IllegalStateException("kafka is down"))
+      .when(changelogConsumerController)
+      .start();
+
+    IllegalStateException thrown = assertThrows(
+      IllegalStateException.class,
+      () -> updater.createOrUpdate()
+    );
+
+    assertEquals("bad export", thrown.getMessage());
+    assertEquals("kafka is down", thrown.getSuppressed()[0].getMessage());
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -18,7 +18,6 @@ server.port=28080
 
 # Antu
 antu.organisation.registry.url=https://notInUse
-antu.stop.registry.id.url=https://notInUse
 antu.netex.job.consumers=1
 
 # The pipeline is driven directly by the tests; nothing subscribes to PubSub
@@ -28,7 +27,7 @@ antu.leader.heartbeat.initial.millis=3600000
 # A real cron, so that booting any test parses it the way production does. @Scheduled parses eagerly, so
 # an unparseable value here fails the context instead of failing a deploy. The job is leader-guarded and
 # the heartbeat above never fires in tests, so it cannot actually run.
-antu.stop.refresh.cron=0 0 1,14 * * *
+antu.stop.refresh.cron=0 */15 * * * *
 
 # Non-default on purpose: SchedulingConfigTest asserts this reaches the scheduler @Scheduled uses.
 # At the default of 1 that assertion cannot fail.


### PR DESCRIPTION
Tiamat writes the export around 02:09 and 12:09; the cache refreshed at 01:00
and 14:00, so it re-read exports it already had and picked up new ones hours
late. A stop place registered just after an export stayed invisible to
validation for up to 26 hours. That is what failed fjl_20260821120458720097 on
NSR:Quay:111871, ten hours after the quay reached the bucket.

The leader now checks the export's GCS generation every 15 minutes and queues a
refresh when it differs from the one the cache was built from. The generation is
recorded at enqueue, so ticks during a running refresh don't re-queue it; a
failed submit or refresh clears it again, conditionally, so a newer export
isn't erased. An empty cache refreshes regardless, on leadership grant only.

Two adjacent fixes, separate commits:

- A dataset parsing to no stop places or quays is refused, not logged and
  accepted. It matters more now: recording at enqueue means a silently accepted
  truncated export would never be read again.
- The changelog consumer comes back in a finally after a refresh, and init()
  and createOrUpdate() take a lock.

Not addressed: nothing detects a consumer that dies on its own, so antu can
still fall back to export-only freshness, now bounded at 15 minutes.