### PR TITLE
Adds validation of NeTEx version attribute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,54 @@ Antu supports multiple validation profiles with different rule sets:
 `config/TimetableDataValidatorConfig.java`, `config/StopPlaceDataValidatorConfig.java` and `config/flex/`,
 and a few interchange validators are behind feature flags that default to off.
 
+Every profile also rejects a file outright if its `PublicationDelivery` declares a NeTEx schema
+version Antu doesn't recognize (`NetexProfileVersionValidator`, wired into
+`validation/NetexValidationProfile.java`). This runs before schema, XPath or JAXB validation, so
+the file never reaches `netex-validator-java`'s `NetexValidatorsRunner`. The allowlist
+(`SUPPORTED_NETEX_SCHEMA_VERSIONS`) is seeded entirely from
+`org.rutebanken.netex.validation.NeTExValidator.NetexVersion` — netex-java-model's own enum of
+schema versions it can validate against — with no hand-added entries on top of it. The `version`
+attribute is read in the three-segment form the Nordic profile declares
+(`1.15:NO-NeTEx-networktimetable:1.5`), and only its first segment is looked up. The shape is part
+of the rule, not just the lookup: a value that doesn't split into three segments — a bare `1.15`,
+say — is rejected too, on the grounds that a version Antu can't read out is not one it can claim to
+support. A file with *no* `version` attribute is the single case that passes unrecognized: there is
+nothing to compare, and schema validation already falls back to its own latest known version. In
+particular
+`"1.16"` is rejected today: `netex-java-model` has no schema for it yet, so it isn't in
+`NetexVersion`, so it isn't in the allowlist either. It starts being accepted automatically, with
+no Antu code change, the day `netex-java-model` adds it. **Bumping `netex-java-model`,
+`netex-parser-java` or `netex-validator-java` in `pom.xml` can silently change which versions
+Antu accepts**, since the allowlist is derived from that enum at compile time — check
+`NetexVersion` for new or removed values when bumping those dependencies. The rule code is
+`UNSUPPORTED_NETEX_VERSION`; like `XML_SCHEMA_ERROR` and `SYSTEM_ERROR`, it's a structural
+pre-flight check, not a per-profile rule, so it isn't listed in the README's rule-code tables.
+
+The check is per file, and a dataset can mix supported and unsupported files: a rejected file
+contributes exactly one entry naming itself and every other file is validated as usual. Rejecting a
+*common* file is the exception — it rejects the shared data the line files resolve their references
+against, so it sets `hasErrorInCommonFile` and the line files skip the NeTEx validators. Without
+that, one bad `_shared_data.xml` buries its own entry under up to 50 spurious
+`NeTEx ID unresolved reference` entries **per line file**, since `ReportAggregator` concatenates
+per-file reports and the 50-per-rule truncation is per file, not global. The flag normally reaches
+the validation state through `AntuNetexValidationProgressCallback` when `NetexValidatorsRunner`
+completes a file; a rejection never runs the runner, so `NetexValidationProfile` sets it directly.
+
+A dataset with several common files needs nothing extra from the check, which is per report rather
+than per common file: any one rejected common file suppresses the NeTEx validators for the whole
+dataset, and a rejected common file still writes its report and arrives at both barriers, so the
+`COMMON_FILES_VALIDATED` count is never left short. Two consequences are worth knowing rather than
+fixing. The flag is read for *every* file that has not been validated yet, siblings included, so
+whichever common file is rejected first also suppresses the NeTEx validators for the other common
+files — and since delivery order is not publish order (pitfall 8), which sibling findings a
+multi-common-file report contains is timing-dependent. And the flag is written read-modify-write
+over an `RLocalCachedMap` (pitfall 5), so a concurrent progress write can lose it and the line
+files get validated after all; that is open item 5 in `docs/camel-removal.md`, which several common
+files make more likely rather than differently broken.
+The version check also sits *after* the `validationAlreadyComplete` guard, so a redelivered job for
+an already-published report reports nothing. `UnsupportedNetexVersionDatasetTest` pins both
+behaviours end to end.
+
 ## Common Tasks
 
 ### Building the Project

--- a/src/main/java/no/entur/antu/config/ValidatorConfig.java
+++ b/src/main/java/no/entur/antu/config/ValidatorConfig.java
@@ -21,6 +21,7 @@ import static no.entur.antu.validation.ValidationProfile.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import no.entur.antu.validation.NetexProfileVersionValidator;
 import no.entur.antu.validation.NetexValidationProfile;
 import no.entur.antu.validation.state.ValidationStateRepository;
 import no.entur.antu.validation.validator.id.NetexIdValidator;
@@ -137,6 +138,11 @@ public class ValidatorConfig {
   }
 
   @Bean
+  public NetexProfileVersionValidator netexProfileVersionValidator() {
+    return new NetexProfileVersionValidator();
+  }
+
+  @Bean
   public NetexValidationProfile netexValidationProfile(
     @Qualifier(
       "timetableDataValidatorsRunner"
@@ -165,7 +171,8 @@ public class ValidatorConfig {
     @Value(
       "${antu.netex.validation.validators.skip:false}"
     ) boolean skipNetexValidators,
-    ValidationStateRepository validationStateRepository
+    ValidationStateRepository validationStateRepository,
+    NetexProfileVersionValidator netexProfileVersionValidator
   ) {
     return new NetexValidationProfile(
       Map.of(
@@ -186,7 +193,8 @@ public class ValidatorConfig {
       ),
       validationStateRepository,
       skipSchemaValidation,
-      skipNetexValidators
+      skipNetexValidators,
+      netexProfileVersionValidator
     );
   }
 }

--- a/src/main/java/no/entur/antu/validation/NetexProfileVersionValidator.java
+++ b/src/main/java/no/entur/antu/validation/NetexProfileVersionValidator.java
@@ -1,0 +1,85 @@
+package no.entur.antu.validation;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.entur.netex.validation.validator.DataLocation;
+import org.entur.netex.validation.validator.Severity;
+import org.entur.netex.validation.validator.ValidationReportEntry;
+import org.entur.netex.validation.xml.PublicationDeliveryVersionAttributeReader;
+import org.rutebanken.netex.validation.NeTExValidator.NetexVersion;
+
+/**
+ * Rejects a NeTEx file outright when its PublicationDelivery declares a NeTEx schema version
+ * Antu doesn't recognize, before any schema, XPath or JAXB validator runs against it.
+ *
+ * <p>The known versions are seeded entirely from {@link NetexVersion}, the single source of
+ * truth netex-java-model itself uses to select an XML schema.
+ */
+public class NetexProfileVersionValidator {
+
+  static final String RULE_CODE = "UNSUPPORTED_NETEX_VERSION";
+
+  static final Set<String> SUPPORTED_NETEX_SCHEMA_VERSIONS = Arrays
+    .stream(NetexVersion.values())
+    .map(NetexVersion::toString)
+    .collect(Collectors.toUnmodifiableSet());
+
+  /**
+   * The version attribute is read in the {@code netexSchemaVersion:profileName:profileVersion} form
+   * the Nordic profile declares, e.g. "1.15:NO-NeTEx-networktimetable:1.5", and only its schema
+   * version segment is compared against {@link #SUPPORTED_NETEX_SCHEMA_VERSIONS}.
+   *
+   * Exactly two things are accepted, and they are not the same case:
+   * - a declared schema version that is on that list;
+   * - a file that declares <em>no</em> version attribute at all. There is nothing to compare,
+   *   and schema validation falls back to its own latest known version, so the file is left to
+   *   the other validators rather than reported.
+   *
+   * @return a CRITICAL report entry for a version Antu does not support, or empty if the file is
+   * left to the other validators.
+   */
+  public Optional<ValidationReportEntry> validate(
+    String fileName,
+    byte[] fileContent
+  ) {
+    String rawVersion =
+      PublicationDeliveryVersionAttributeReader.findPublicationDeliveryVersion(
+        fileContent
+      );
+    if (rawVersion == null) {
+      return Optional.empty();
+    }
+
+    Optional<String> netexSchemaVersion = schemaVersionSegment(rawVersion);
+    if (
+      netexSchemaVersion.isPresent() &&
+      SUPPORTED_NETEX_SCHEMA_VERSIONS.contains(netexSchemaVersion.get())
+    ) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+      new ValidationReportEntry(
+        "NeTEx profile version " + rawVersion + " is not supported by Antu",
+        RULE_CODE,
+        Severity.CRITICAL,
+        new DataLocation(null, fileName, null, null)
+      )
+    );
+  }
+
+  /**
+   * The PublicationDelivery version attribute has the form
+   * {netexSchemaVersion}:{profileName}:{profileVersion}, e.g.
+   * "1.15:NO-NeTEx-networktimetable:1.5". Only the first segment is the NeTEx schema version.
+   * Empty if {@code rawVersion} doesn't match that 3-segment grammar - the same split
+   * {@code NetexSchemaRepository.getSchemaVersion} applies, though it treats a value it can't read
+   * as a reason to fall back to the latest schema rather than as a reason to reject the file.
+   */
+  private static Optional<String> schemaVersionSegment(String rawVersion) {
+    String[] segments = rawVersion.split(":");
+    return segments.length == 3 ? Optional.of(segments[0]) : Optional.empty();
+  }
+}

--- a/src/main/java/no/entur/antu/validation/NetexValidationProfile.java
+++ b/src/main/java/no/entur/antu/validation/NetexValidationProfile.java
@@ -1,12 +1,15 @@
 package no.entur.antu.validation;
 
 import java.util.Map;
+import java.util.Optional;
 import no.entur.antu.config.cache.ValidationState;
 import no.entur.antu.exception.AntuException;
+import no.entur.antu.job.AntuJob;
 import no.entur.antu.validation.state.ValidationStateRepository;
 import org.entur.netex.validation.validator.NetexValidationProgressCallBack;
 import org.entur.netex.validation.validator.NetexValidatorsRunner;
 import org.entur.netex.validation.validator.ValidationReport;
+import org.entur.netex.validation.validator.ValidationReportEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,17 +27,20 @@ public class NetexValidationProfile {
   private final ValidationStateRepository validationStateRepository;
   private final boolean skipSchemaValidation;
   private final boolean skipNetexValidators;
+  private final NetexProfileVersionValidator netexProfileVersionValidator;
 
   public NetexValidationProfile(
     Map<ValidationProfile, NetexValidatorsRunner> netexValidatorsRunners,
     ValidationStateRepository validationStateRepository,
     boolean skipSchemaValidation,
-    boolean skipNetexValidators
+    boolean skipNetexValidators,
+    NetexProfileVersionValidator netexProfileVersionValidator
   ) {
     this.netexValidatorsRunners = netexValidatorsRunners;
     this.validationStateRepository = validationStateRepository;
     this.skipSchemaValidation = skipSchemaValidation;
     this.skipNetexValidators = skipNetexValidators;
+    this.netexProfileVersionValidator = netexProfileVersionValidator;
   }
 
   /**
@@ -61,6 +67,7 @@ public class NetexValidationProfile {
     if (codespace == null) {
       throw new AntuException("Missing codespace");
     }
+
     NetexValidatorsRunner netexValidatorsRunner = getNetexValidatorsRunner(
       validationProfile
     );
@@ -70,6 +77,17 @@ public class NetexValidationProfile {
     );
     if (validationAlreadyComplete) {
       LOGGER.info("The validation is already complete, ignoring");
+    } else {
+      Optional<ValidationReportEntry> unsupportedVersion =
+        netexProfileVersionValidator.validate(filename, fileContent);
+      if (unsupportedVersion.isPresent()) {
+        return rejectUnsupportedVersion(
+          codespace,
+          validationReportId,
+          filename,
+          unsupportedVersion.get()
+        );
+      }
     }
     boolean hasErrorInCommonFile = validationHasErrorInCommonFile(
       validationReportId
@@ -87,6 +105,51 @@ public class NetexValidationProfile {
       skipSchemaValidation || validationAlreadyComplete,
       skipNetexValidators || validationAlreadyComplete || hasErrorInCommonFile,
       netexValidationProgressCallBack
+    );
+  }
+
+  /**
+   * A file declaring a NeTEx version Antu does not support is reported and nothing else is run
+   * against it.
+   *
+   * <p>Rejecting a common file rejects the shared data every line file resolves its references
+   * against, so the line files skip the NeTEx validators: every reference into the missing shared
+   * data would otherwise be reported as unresolved, which says nothing about the line file. That is
+   * the same suppression a common file with a schema error triggers, except that one reaches the
+   * validation state through {@link AntuNetexValidationProgressCallback} when the runner completes.
+   * Nothing runs the runner here, so the flag has to be set directly.
+   */
+  private ValidationReport rejectUnsupportedVersion(
+    String codespace,
+    String validationReportId,
+    String filename,
+    ValidationReportEntry unsupportedVersion
+  ) {
+    LOGGER.info(
+      "Rejecting NeTEx file {}: {}",
+      filename,
+      unsupportedVersion.getMessage()
+    );
+    if (AntuJob.isCommonFile(filename)) {
+      markErrorInCommonFile(validationReportId);
+    }
+    ValidationReport validationReport = new ValidationReport(
+      codespace,
+      validationReportId
+    );
+    validationReport.addValidationReportEntry(unsupportedVersion);
+    return validationReport;
+  }
+
+  private void markErrorInCommonFile(String validationReportId) {
+    ValidationState validationState = getValidationState(validationReportId);
+    if (validationState == null) {
+      return;
+    }
+    validationState.setHasErrorInCommonFile(true);
+    validationStateRepository.updateValidationState(
+      validationReportId,
+      validationState
     );
   }
 

--- a/src/test/java/no/entur/antu/pipeline/AntuPipelineTestBase.java
+++ b/src/test/java/no/entur/antu/pipeline/AntuPipelineTestBase.java
@@ -82,6 +82,18 @@ public abstract class AntuPipelineTestBase {
   protected String uploadTestDataset(String codespace, String fileName) {
     InputStream dataset = getClass().getResourceAsStream('/' + fileName);
     assertNotNull(dataset, "Test dataset file not found: " + fileName);
+    return uploadTestDataset(codespace, fileName, dataset);
+  }
+
+  /**
+   * Put a dataset the test assembled itself where a validation client would have left it. Only the
+   * blob name is derived from {@code fileName}; nothing in the pipeline reads it.
+   */
+  protected String uploadTestDataset(
+    String codespace,
+    String fileName,
+    InputStream dataset
+  ) {
     String datasetBlobName =
       BLOBSTORE_PATH_ANTU_EXCHANGE_INBOUND_RECEIVED +
       codespace +

--- a/src/test/java/no/entur/antu/pipeline/UnsupportedNetexVersionDatasetTest.java
+++ b/src/test/java/no/entur/antu/pipeline/UnsupportedNetexVersionDatasetTest.java
@@ -1,0 +1,181 @@
+package no.entur.antu.pipeline;
+
+import static no.entur.antu.validation.ValidationProfile.TIMETABLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+import no.entur.antu.job.ValidationContext;
+import org.entur.netex.validation.validator.ValidationReport;
+import org.entur.netex.validation.validator.ValidationReportEntry;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A dataset holds several NeTEx files, and only some of them may declare a NeTEx version Antu does
+ * not support. What each of the others reports depends on whether the rejected file was a common
+ * file: a rejected line file concerns only itself, while a rejected common file takes the shared
+ * data every line file resolves its references against with it.
+ */
+class UnsupportedNetexVersionDatasetTest extends AntuPipelineTestBase {
+
+  private static final String CODESPACE_FLB = "flb";
+  private static final String DATASET = "rb_flb-aggregated-netex.zip";
+  private static final String COMMON_FILE = "_FLB_shared_data.xml";
+  private static final String LINE_FILE = "FLB_FLB-Line-42_42_Flamsbana.xml";
+  private static final String UNSUPPORTED_NETEX_VERSION =
+    "UNSUPPORTED_NETEX_VERSION";
+
+  private static final String UNSUPPORTED_VERSION_ATTRIBUTE =
+    "2:NO-NeTEx-networktimetable:2";
+
+  /**
+   * The version attribute on the root element, as opposed to the {@code version="1.0"} of the XML
+   * declaration on the line above it.
+   */
+  private static final Pattern PUBLICATION_DELIVERY_VERSION = Pattern.compile(
+    "(<PublicationDelivery\\b[^>]*?)version=\"[^\"]*\""
+  );
+
+  /**
+   * The rejection is attributed to the file that declared the unsupported version, and the rest of
+   * the dataset is validated as usual - here the common file still reports its own findings.
+   */
+  @Test
+  void aRejectedLineFileDoesNotAffectTheOtherFiles() throws Exception {
+    ValidationReport report = validateDatasetWithUnsupportedVersionIn(
+      LINE_FILE
+    );
+
+    assertEquals(
+      List.of(UNSUPPORTED_NETEX_VERSION),
+      ruleNamesFor(report, LINE_FILE)
+    );
+    assertFalse(
+      entriesFor(report, COMMON_FILE).isEmpty(),
+      "The common file declares a supported version and should have been validated normally"
+    );
+    assertFalse(
+      ruleNamesFor(report, COMMON_FILE).contains(UNSUPPORTED_NETEX_VERSION)
+    );
+  }
+
+  /**
+   * A rejected common file is never parsed, so every reference a line file makes into the shared
+   * data would be reported as unresolved. Those findings are consequences of the rejection and say
+   * nothing about the line file, so the line files skip the NeTEx validators - the same suppression
+   * a common file with a schema error triggers.
+   */
+  @Test
+  void aRejectedCommonFileSuppressesTheLineFileFindings() throws Exception {
+    ValidationReport report = validateDatasetWithUnsupportedVersionIn(
+      COMMON_FILE
+    );
+
+    assertEquals(
+      List.of(UNSUPPORTED_NETEX_VERSION),
+      ruleNamesFor(report, COMMON_FILE)
+    );
+    assertEquals(
+      List.of(),
+      ruleNamesFor(report, LINE_FILE),
+      "The line file should report nothing once its common file was rejected"
+    );
+    assertTrue(report.hasError());
+  }
+
+  private ValidationReport validateDatasetWithUnsupportedVersionIn(
+    String fileName
+  ) throws Exception {
+    String datasetBlobName = uploadTestDataset(
+      CODESPACE_FLB,
+      "rb_flb-unsupported-version-in-" + fileName + ".zip",
+      new ByteArrayInputStream(datasetWithUnsupportedVersionIn(fileName))
+    );
+    ValidationContext context = validate(
+      CODESPACE_FLB,
+      datasetBlobName,
+      TIMETABLE.id()
+    );
+    return publishedReport(context);
+  }
+
+  /**
+   * Both variants of this dataset are one attribute away from the dataset every other pipeline test
+   * uses, so they are assembled here instead of being checked in as two more near-identical zips.
+   * What makes a file unsupported then stays readable, rather than being buried in a binary.
+   */
+  private static byte[] datasetWithUnsupportedVersionIn(String fileName)
+    throws IOException {
+    ByteArrayOutputStream rewrittenDataset = new ByteArrayOutputStream();
+    InputStream dataset =
+      UnsupportedNetexVersionDatasetTest.class.getResourceAsStream(
+          '/' + DATASET
+        );
+    assertNotNull(dataset, "Test dataset file not found: " + DATASET);
+    boolean rewroteAFile = false;
+    try (
+      ZipInputStream source = new ZipInputStream(dataset);
+      ZipOutputStream target = new ZipOutputStream(rewrittenDataset)
+    ) {
+      for (ZipEntry entry; (entry = source.getNextEntry()) != null;) {
+        byte[] netexFile = source.readAllBytes();
+        boolean rewriteThisFile = fileName.equals(entry.getName());
+        rewroteAFile |= rewriteThisFile;
+        target.putNextEntry(new ZipEntry(entry.getName()));
+        target.write(
+          rewriteThisFile ? withUnsupportedVersion(netexFile) : netexFile
+        );
+        target.closeEntry();
+      }
+    }
+    assertTrue(rewroteAFile, DATASET + " holds no file named " + fileName);
+    return rewrittenDataset.toByteArray();
+  }
+
+  private static byte[] withUnsupportedVersion(byte[] netexFile) {
+    Matcher versionAttribute = PUBLICATION_DELIVERY_VERSION.matcher(
+      new String(netexFile, StandardCharsets.UTF_8)
+    );
+    assertTrue(
+      versionAttribute.find(),
+      "The PublicationDelivery declares no version attribute to make unsupported"
+    );
+    return versionAttribute
+      .replaceFirst("$1version=\"" + UNSUPPORTED_VERSION_ATTRIBUTE + "\"")
+      .getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static List<ValidationReportEntry> entriesFor(
+    ValidationReport report,
+    String fileName
+  ) {
+    return report
+      .getValidationReportEntries()
+      .stream()
+      .filter(entry -> fileName.equals(entry.getFileName()))
+      .toList();
+  }
+
+  private static List<String> ruleNamesFor(
+    ValidationReport report,
+    String fileName
+  ) {
+    return entriesFor(report, fileName)
+      .stream()
+      .map(ValidationReportEntry::getName)
+      .distinct()
+      .toList();
+  }
+}

--- a/src/test/java/no/entur/antu/validation/NetexProfileVersionValidatorTest.java
+++ b/src/test/java/no/entur/antu/validation/NetexProfileVersionValidatorTest.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import org.entur.netex.validation.validator.Severity;
 import org.entur.netex.validation.validator.ValidationReportEntry;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class NetexProfileVersionValidatorTest {
 
@@ -45,24 +47,6 @@ class NetexProfileVersionValidatorTest {
     );
   }
 
-  /**
-   * "1.5" was never a published NeTEx schema version (versions go ...1.04, 1.07, 1.08 ... 1.15).
-   * It isn't in the allowlist, so it's rejected — unlike under a numeric "greater than 1.16"
-   * ceiling, which would have accepted it because 1.5 sorts below 1.16 as a decimal.
-   */
-  @Test
-  void aNeverPublishedVersionIsRejectedEvenThoughItWouldSortBelowTheHighestKnownVersionNumerically() {
-    byte[] content = publicationDelivery("1.5:NO-NeTEx-networktimetable:1.0");
-
-    Optional<ValidationReportEntry> entry = validator.validate(
-      "netex.xml",
-      content
-    );
-
-    assertTrue(entry.isPresent());
-    assertEquals("UNSUPPORTED_NETEX_VERSION", entry.get().getName());
-  }
-
   @Test
   void aFileWithNoRecognizableVersionAttributeIsLeftToOtherValidators() {
     byte[] content = "<PublicationDelivery/>".getBytes();
@@ -71,32 +55,28 @@ class NetexProfileVersionValidatorTest {
   }
 
   /**
-   * A version attribute is present but doesn't match the
-   * netexSchemaVersion:profileName:profileVersion grammar, so there's no schema-version segment to
-   * look up — treated the same as an unsupported version, not left to other validators. A version
-   * that can't be read is not a version Antu can claim to support, even when the string happens to
-   * name a supported one. Only a file with no version attribute at all is accepted.
+   * The ways a declared version fails, which all end in the same rejection: a schema version that
+   * isn't in the allowlist, and a value the schema version can't be read out of at all. What the
+   * entry itself looks like is asserted once, in
+   * {@link #anUnknownMajorVersionIsRejected()}.
    */
-  @Test
-  void aVersionAttributeWithoutTheThreeColonSegmentsIsRejected() {
-    byte[] content = publicationDelivery("1.15");
-
-    Optional<ValidationReportEntry> entry = validator.validate(
-      "netex.xml",
-      content
-    );
-
-    assertTrue(entry.isPresent());
-    assertEquals("UNSUPPORTED_NETEX_VERSION", entry.get().getName());
-  }
-
-  /**
-   * The same rejection, for a value that names no NeTEx version at all rather than one in the wrong
-   * shape.
-   */
-  @Test
-  void aVersionAttributeThatNamesNoNetexVersionIsRejected() {
-    byte[] content = publicationDelivery("any");
+  @ParameterizedTest
+  @ValueSource(
+    strings = {
+      // Never a published NeTEx schema version (they go ...1.04, 1.07, 1.08 ... 1.15). It sorts
+      // below the highest known version as a decimal, so a numeric ceiling would have let it
+      // through; the allowlist doesn't.
+      "1.5:NO-NeTEx-networktimetable:1.0",
+      // A supported schema version, but with no profile segments to make it the three-segment form,
+      // so there is no schema version segment to look up. A version that can't be read out is not
+      // one Antu can claim to support, even when the string happens to name one that is.
+      "1.15",
+      // Names no NeTEx version at all.
+      "any",
+    }
+  )
+  void anUnsupportedOrUnreadableVersionIsRejected(String versionAttribute) {
+    byte[] content = publicationDelivery(versionAttribute);
 
     Optional<ValidationReportEntry> entry = validator.validate(
       "netex.xml",

--- a/src/test/java/no/entur/antu/validation/NetexProfileVersionValidatorTest.java
+++ b/src/test/java/no/entur/antu/validation/NetexProfileVersionValidatorTest.java
@@ -1,0 +1,115 @@
+package no.entur.antu.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.entur.netex.validation.validator.Severity;
+import org.entur.netex.validation.validator.ValidationReportEntry;
+import org.junit.jupiter.api.Test;
+
+class NetexProfileVersionValidatorTest {
+
+  private final NetexProfileVersionValidator validator =
+    new NetexProfileVersionValidator();
+
+  @Test
+  void aVersionFromTheNetexJavaModelEnumIsAccepted() {
+    byte[] content = publicationDelivery("1.08:NO-NeTEx-networktimetable:1.1");
+
+    assertEquals(Optional.empty(), validator.validate("netex.xml", content));
+  }
+
+  @Test
+  void theCurrentNordicProfileVersionIsAccepted() {
+    byte[] content = publicationDelivery("1.15:NO-NeTEx-networktimetable:1.5");
+
+    assertEquals(Optional.empty(), validator.validate("netex.xml", content));
+  }
+
+  @Test
+  void anUnknownMajorVersionIsRejected() {
+    byte[] content = publicationDelivery("2:NO-NeTEx-networktimetable:2");
+
+    Optional<ValidationReportEntry> entry = validator.validate(
+      "netex.xml",
+      content
+    );
+
+    assertTrue(entry.isPresent());
+    assertEquals("UNSUPPORTED_NETEX_VERSION", entry.get().getName());
+    assertEquals(Severity.CRITICAL, entry.get().getSeverity());
+    assertEquals("netex.xml", entry.get().getFileName());
+    assertTrue(
+      entry.get().getMessage().contains("2:NO-NeTEx-networktimetable:2")
+    );
+  }
+
+  /**
+   * "1.5" was never a published NeTEx schema version (versions go ...1.04, 1.07, 1.08 ... 1.15).
+   * It isn't in the allowlist, so it's rejected — unlike under a numeric "greater than 1.16"
+   * ceiling, which would have accepted it because 1.5 sorts below 1.16 as a decimal.
+   */
+  @Test
+  void aNeverPublishedVersionIsRejectedEvenThoughItWouldSortBelowTheHighestKnownVersionNumerically() {
+    byte[] content = publicationDelivery("1.5:NO-NeTEx-networktimetable:1.0");
+
+    Optional<ValidationReportEntry> entry = validator.validate(
+      "netex.xml",
+      content
+    );
+
+    assertTrue(entry.isPresent());
+    assertEquals("UNSUPPORTED_NETEX_VERSION", entry.get().getName());
+  }
+
+  @Test
+  void aFileWithNoRecognizableVersionAttributeIsLeftToOtherValidators() {
+    byte[] content = "<PublicationDelivery/>".getBytes();
+
+    assertEquals(Optional.empty(), validator.validate("netex.xml", content));
+  }
+
+  /**
+   * A version attribute is present but doesn't match the
+   * netexSchemaVersion:profileName:profileVersion grammar, so there's no schema-version segment to
+   * look up — treated the same as an unsupported version, not left to other validators. A version
+   * that can't be read is not a version Antu can claim to support, even when the string happens to
+   * name a supported one. Only a file with no version attribute at all is accepted.
+   */
+  @Test
+  void aVersionAttributeWithoutTheThreeColonSegmentsIsRejected() {
+    byte[] content = publicationDelivery("1.15");
+
+    Optional<ValidationReportEntry> entry = validator.validate(
+      "netex.xml",
+      content
+    );
+
+    assertTrue(entry.isPresent());
+    assertEquals("UNSUPPORTED_NETEX_VERSION", entry.get().getName());
+  }
+
+  /**
+   * The same rejection, for a value that names no NeTEx version at all rather than one in the wrong
+   * shape.
+   */
+  @Test
+  void aVersionAttributeThatNamesNoNetexVersionIsRejected() {
+    byte[] content = publicationDelivery("any");
+
+    Optional<ValidationReportEntry> entry = validator.validate(
+      "netex.xml",
+      content
+    );
+
+    assertTrue(entry.isPresent());
+    assertEquals("UNSUPPORTED_NETEX_VERSION", entry.get().getName());
+  }
+
+  private static byte[] publicationDelivery(String version) {
+    return (
+      "<PublicationDelivery version=\"" + version + "\"></PublicationDelivery>"
+    ).getBytes();
+  }
+}

--- a/src/test/java/no/entur/antu/validation/NetexValidationProfileTest.java
+++ b/src/test/java/no/entur/antu/validation/NetexValidationProfileTest.java
@@ -1,0 +1,160 @@
+package no.entur.antu.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import no.entur.antu.config.cache.ValidationState;
+import no.entur.antu.validation.state.ValidationStateRepository;
+import org.entur.netex.validation.validator.NetexValidationProgressCallBack;
+import org.entur.netex.validation.validator.NetexValidatorsRunner;
+import org.entur.netex.validation.validator.ValidationReport;
+import org.entur.netex.validation.validator.ValidationReportEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class NetexValidationProfileTest {
+
+  private static final String LINE_FILE = "netex.xml";
+  private static final String COMMON_FILE = "_shared_data.xml";
+  private static final String SUPPORTED_VERSION_CONTENT =
+    "<PublicationDelivery version=\"1.15:NO-NeTEx-networktimetable:1.5\"></PublicationDelivery>";
+  private static final String UNSUPPORTED_VERSION_CONTENT =
+    "<PublicationDelivery version=\"2:NO-NeTEx-networktimetable:2\"></PublicationDelivery>";
+
+  private NetexValidatorsRunner netexValidatorsRunner;
+  private ValidationStateRepository validationStateRepository;
+  private ValidationState validationState;
+  private NetexValidationProfile netexValidationProfile;
+
+  @BeforeEach
+  void setUp() {
+    netexValidatorsRunner = mock(NetexValidatorsRunner.class);
+    validationStateRepository = mock(ValidationStateRepository.class);
+    validationState = new ValidationState();
+    // A state that is present is what marks the validation as still running.
+    when(validationStateRepository.getValidationState(anyString()))
+      .thenReturn(validationState);
+    netexValidationProfile =
+      new NetexValidationProfile(
+        Map.of(ValidationProfile.TIMETABLE, netexValidatorsRunner),
+        validationStateRepository,
+        false,
+        false,
+        new NetexProfileVersionValidator()
+      );
+  }
+
+  @Test
+  void aFileWithASupportedVersionIsDelegatedToTheRunner() {
+    byte[] fileContent = SUPPORTED_VERSION_CONTENT.getBytes();
+    ValidationReport expectedReport = new ValidationReport("tst", "reportId");
+    when(
+      netexValidatorsRunner.validate(
+        eq("tst"),
+        eq("reportId"),
+        eq(LINE_FILE),
+        eq(fileContent),
+        anyBoolean(),
+        anyBoolean(),
+        any()
+      )
+    )
+      .thenReturn(expectedReport);
+
+    assertSame(expectedReport, validate(LINE_FILE, fileContent));
+  }
+
+  @Test
+  void aFileWithAnUnsupportedVersionIsRejectedWithoutRunningTheValidators() {
+    ValidationReport report = validate(
+      LINE_FILE,
+      UNSUPPORTED_VERSION_CONTENT.getBytes()
+    );
+
+    assertTrue(report.hasError());
+    assertEquals(
+      List.of("UNSUPPORTED_NETEX_VERSION"),
+      report
+        .getValidationReportEntries()
+        .stream()
+        .map(ValidationReportEntry::getName)
+        .toList()
+    );
+    verify(netexValidatorsRunner, never())
+      .validate(any(), any(), any(), any(), anyBoolean(), anyBoolean(), any());
+  }
+
+  /**
+   * Rejecting a common file rejects the shared data the line files resolve their references
+   * against, so they have to be told to skip the NeTEx validators. Nothing runs the validators
+   * runner on this path, so its completion callback cannot be what records this.
+   */
+  @Test
+  void aRejectedCommonFileMarksTheValidationAsFailedInACommonFile() {
+    validate(COMMON_FILE, UNSUPPORTED_VERSION_CONTENT.getBytes());
+
+    assertTrue(validationState.hasErrorInCommonFile());
+    verify(validationStateRepository)
+      .updateValidationState(eq("reportId"), any());
+  }
+
+  @Test
+  void aRejectedLineFileLeavesTheOtherFilesAlone() {
+    validate(LINE_FILE, UNSUPPORTED_VERSION_CONTENT.getBytes());
+
+    assertFalse(validationState.hasErrorInCommonFile());
+    verify(validationStateRepository, never())
+      .updateValidationState(any(), any());
+  }
+
+  /**
+   * A missing state means the validation already reached a terminal status. A redelivered job then
+   * has nothing to add, so it must not report a rejection against a report that is already
+   * published.
+   */
+  @Test
+  void anAlreadyCompletedValidationRejectsNothing() {
+    when(validationStateRepository.getValidationState(anyString()))
+      .thenReturn(null);
+    byte[] fileContent = UNSUPPORTED_VERSION_CONTENT.getBytes();
+    ValidationReport emptyReport = new ValidationReport("tst", "reportId");
+    when(
+      netexValidatorsRunner.validate(
+        any(),
+        any(),
+        any(),
+        any(),
+        anyBoolean(),
+        anyBoolean(),
+        any()
+      )
+    )
+      .thenReturn(emptyReport);
+
+    assertSame(emptyReport, validate(COMMON_FILE, fileContent));
+    assertFalse(validationState.hasErrorInCommonFile());
+  }
+
+  private ValidationReport validate(String filename, byte[] fileContent) {
+    return netexValidationProfile.validate(
+      "timetable",
+      "tst",
+      "reportId",
+      filename,
+      fileContent,
+      mock(NetexValidationProgressCallBack.class)
+    );
+  }
+}


### PR DESCRIPTION
This commit ensures that if a NeTEx dataset's PublicationDelivery.version attribute point to a version that netex-java-model - and thereby Antu's schema validation - is not aware of, a CRITICAL validation report entry is created for that validation report. This is a step of validation done before the schema validation itself, and if it fails, no XSD validation is done for that file.