### PR TITLE
Start the changelog consumer only on the leader

### DIFF
--- a/src/main/java/no/entur/antu/config/StopPlaceChangelogConfig.java
+++ b/src/main/java/no/entur/antu/config/StopPlaceChangelogConfig.java
@@ -16,6 +16,7 @@
 
 package no.entur.antu.config;
 
+import no.entur.antu.leader.LeaderElection;
 import no.entur.antu.stop.StopPlaceRepositoryLoader;
 import no.entur.antu.stop.changelog.AntuPublicationTimeRecordFilterStrategy;
 import no.entur.antu.stop.changelog.AntuStopPlaceChangeLogListener;
@@ -63,7 +64,8 @@ public class StopPlaceChangelogConfig {
     RedisChangelogUpdateTimestampRepository changelogUpdateTimestampRepository,
     ChangelogConsumerController changelogConsumerController,
     StopPlaceChangelog stopPlaceChangelog,
-    AntuStopPlaceChangeLogListener antuStopPlaceChangeLogListener
+    AntuStopPlaceChangeLogListener antuStopPlaceChangeLogListener,
+    LeaderElection leaderElection
   ) {
     return new ChangelogStopPlaceRepositoryUpdater(
       stopPlaceRepositoryLoader,
@@ -71,7 +73,8 @@ public class StopPlaceChangelogConfig {
       changelogUpdateTimestampRepository,
       changelogConsumerController,
       stopPlaceChangelog,
-      antuStopPlaceChangeLogListener
+      antuStopPlaceChangeLogListener,
+      leaderElection
     );
   }
 }

--- a/src/main/java/no/entur/antu/leader/LeadershipLostEvent.java
+++ b/src/main/java/no/entur/antu/leader/LeadershipLostEvent.java
@@ -1,0 +1,10 @@
+package no.entur.antu.leader;
+
+/**
+ * Published on the pod that has just stopped being leader.
+ *
+ * <p>The counterpart to {@link LeadershipGrantedEvent}: whatever a pod started on taking over has to be
+ * stood down again, or it keeps running alongside the new leader's.
+ */
+@SuppressWarnings("java:S2094")
+public record LeadershipLostEvent() {}

--- a/src/main/java/no/entur/antu/leader/RedisLeaseLeaderElection.java
+++ b/src/main/java/no/entur/antu/leader/RedisLeaseLeaderElection.java
@@ -69,6 +69,21 @@ public class RedisLeaseLeaderElection implements LeaderElection {
       return thread;
     });
 
+  /**
+   * Standing down has its own thread. Queued behind a takeover it would wait for a prime that parses the
+   * national dataset, and by then the pod that took the lease is already consuming: the two consumers this
+   * is meant to prevent, for as long as the prime lasts.
+   *
+   * <p>Two threads means the two can also run out of order, so what starts the consumer checks leadership
+   * for itself rather than trusting the order it was told in.
+   */
+  private final ExecutorService leadershipRevocations =
+    Executors.newSingleThreadExecutor(runnable -> {
+      Thread thread = new Thread(runnable, "antu-leadership-revocation");
+      thread.setDaemon(true);
+      return thread;
+    });
+
   private volatile boolean leader;
 
   /**
@@ -96,6 +111,7 @@ public class RedisLeaseLeaderElection implements LeaderElection {
   @PreDestroy
   void stopLeadershipCallbacks() {
     leadershipCallbacks.shutdownNow();
+    leadershipRevocations.shutdownNow();
   }
 
   /**
@@ -125,7 +141,7 @@ public class RedisLeaseLeaderElection implements LeaderElection {
     } catch (Exception e) {
       // A lost Redis connection must not leave a stale leader believing it still owns the lease.
       LOGGER.warn("Leader election heartbeat failed: {}", e.getMessage());
-      leader = false;
+      stepDown();
     }
   }
 
@@ -165,7 +181,25 @@ public class RedisLeaseLeaderElection implements LeaderElection {
     }
     // The lease is gone or belongs to someone else now. Stepping aside is what keeps the single-leader
     // guarantee.
-    leader = false;
     LOGGER.warn("Leadership lost by {}", podId);
+    stepDown();
+  }
+
+  /**
+   * Announced only on the transition, and off the heartbeat thread: listeners stop things that block, and
+   * a heartbeat that waits on them is a heartbeat that misses the next renewal.
+   */
+  private void stepDown() {
+    if (!leader) {
+      return;
+    }
+    leader = false;
+    leadershipRevocations.execute(() -> {
+      try {
+        eventPublisher.publishEvent(new LeadershipLostEvent());
+      } catch (Exception e) {
+        LOGGER.error("Standing down as leader failed", e);
+      }
+    });
   }
 }

--- a/src/main/java/no/entur/antu/pipeline/StopPlaceCacheRefresher.java
+++ b/src/main/java/no/entur/antu/pipeline/StopPlaceCacheRefresher.java
@@ -4,6 +4,7 @@ import no.entur.antu.job.AntuJob;
 import no.entur.antu.job.JobQueue;
 import no.entur.antu.leader.LeaderElection;
 import no.entur.antu.leader.LeadershipGrantedEvent;
+import no.entur.antu.leader.LeadershipLostEvent;
 import no.entur.antu.stop.StopPlaceDatasetVersionRepository;
 import no.entur.antu.stop.StopPlaceRepositoryLoader;
 import no.entur.antu.stop.changelog.StopPlaceRepositoryUpdater;
@@ -71,6 +72,23 @@ public class StopPlaceCacheRefresher {
       LOGGER.error(
         "System error: failed to prime the stop place cache on taking over as leader. Validations will " +
         "report unresolved stop place references until it is refreshed.",
+        e
+      );
+    }
+  }
+
+  /**
+   * The changelog consumer is the leader's, so it goes down with the leadership. Nothing else here needs
+   * standing down: the caches are shared, and the next leader picks them up as they are.
+   */
+  @EventListener
+  public void onLeadershipLost(LeadershipLostEvent event) {
+    try {
+      stopPlaceRepositoryUpdater.standDown();
+    } catch (Exception e) {
+      LOGGER.error(
+        "System error: failed to stop the stop place changelog consumer after losing leadership. It is " +
+        "consuming alongside the new leader's.",
         e
       );
     }

--- a/src/main/java/no/entur/antu/stop/changelog/ChangelogStopPlaceRepositoryUpdater.java
+++ b/src/main/java/no/entur/antu/stop/changelog/ChangelogStopPlaceRepositoryUpdater.java
@@ -2,6 +2,7 @@ package no.entur.antu.stop.changelog;
 
 import java.time.Duration;
 import java.time.Instant;
+import no.entur.antu.leader.LeaderElection;
 import no.entur.antu.stop.StopPlaceRepositoryLoader;
 import org.rutebanken.helper.stopplace.changelog.StopPlaceChangelog;
 import org.rutebanken.helper.stopplace.changelog.kafka.ChangelogConsumerController;
@@ -25,6 +26,7 @@ public class ChangelogStopPlaceRepositoryUpdater
   private final ChangelogConsumerController changelogConsumerController;
   private final StopPlaceChangelog stopPlaceChangelog;
   private final AntuStopPlaceChangeLogListener handler;
+  private final LeaderElection leaderElection;
 
   public ChangelogStopPlaceRepositoryUpdater(
     StopPlaceRepositoryLoader stopPlaceRepositoryLoader,
@@ -32,7 +34,8 @@ public class ChangelogStopPlaceRepositoryUpdater
     RedisChangelogUpdateTimestampRepository changelogUpdateTimestampRepository,
     ChangelogConsumerController changelogConsumerController,
     StopPlaceChangelog stopPlaceChangelog,
-    AntuStopPlaceChangeLogListener handler
+    AntuStopPlaceChangeLogListener handler,
+    LeaderElection leaderElection
   ) {
     this.stopPlaceRepositoryLoader = stopPlaceRepositoryLoader;
     this.antuPublicationTimeRecordFilterStrategy =
@@ -42,14 +45,14 @@ public class ChangelogStopPlaceRepositoryUpdater
     this.changelogConsumerController = changelogConsumerController;
     this.stopPlaceChangelog = stopPlaceChangelog;
     this.handler = handler;
+    this.leaderElection = leaderElection;
   }
 
   /**
-   * Synchronized against {@link #createOrUpdate()}, which is only a same-pod guard: the two run on
-   * different threads of one pod when a refresh job lands on the pod that is taking over as leader, and
-   * starting the consumer while the refresh has its listener unregistered drops every change it reads.
-   * Refresh jobs run on an arbitrary pod, so the cross-pod case is not covered by this and needs a
-   * distributed lock or a leader-local refresh.
+   * Synchronized against {@link #createOrUpdate()}: the two run on different threads when a refresh job
+   * lands on the pod that is taking over as leader, and starting the consumer while the refresh has its
+   * listener unregistered drops every change it reads. Only the leader touches the consumer, so both are
+   * always on the same pod and the monitor is enough.
    */
   @Override
   public synchronized void init() {
@@ -59,8 +62,7 @@ public class ChangelogStopPlaceRepositoryUpdater
       timestamp = Instant.now().minus(Duration.ofDays(1));
     }
     antuPublicationTimeRecordFilterStrategy.setPublicationTime(timestamp);
-    stopPlaceChangelog.registerStopPlaceChangelogListener(handler);
-    changelogConsumerController.start();
+    startConsumerIfLeader();
     LOGGER.info(
       "Changelog Stop Place Repository Updater initialized with publication timestamp {}",
       timestamp
@@ -68,32 +70,58 @@ public class ChangelogStopPlaceRepositoryUpdater
   }
 
   /**
-   * The consumer comes back whether or not the refresh worked: a refresh that throws would otherwise leave
-   * it stopped with its listener unregistered until the next refresh or the next leader.
-   *
-   * <p>A restart failure is not swallowed. Returning normally tells the refresher the cache was rebuilt,
-   * which keeps the recorded version and stops the checks from retrying, so a transient Kafka failure
-   * would leave the changelog dead until the next export. When the refresh failed too, that exception is
-   * the one that propagates and the restart failure rides along as suppressed.
+   * Synchronized like {@link #init()}: this arrives on the event thread while a refresh may be running,
+   * and stopping the consumer between the refresh's restart check and the start itself would be undone.
+   */
+  @Override
+  public synchronized void standDown() {
+    LOGGER.info("No longer leader, stopping the stop place changelog consumer");
+    // Unregistered before the consumer is stopped, and stopped even if that throws: it is the listener,
+    // not the consumer, that puts records into the shared cache, so a Kafka shutdown that fails leaves a
+    // consumer reading records nobody applies rather than one still writing as the new leader takes over.
+    try {
+      stopPlaceChangelog.unregisterStopPlaceChangelogListener(handler);
+    } finally {
+      changelogConsumerController.stop();
+    }
+  }
+
+  /**
+   * The cache is rebuilt on whichever pod picks the refresh job off the queue, but the changelog consumer
+   * belongs to the leader: init() is the only thing that starts one, and that runs on taking over as
+   * leader. A pod without a consumer must not come out of a refresh with one - nothing would stop it
+   * again, and it would replay the whole retained topic on top of the leader's.
    */
   @Override
   public synchronized void createOrUpdate() {
+    if (leaderElection.isLeader()) {
+      refreshWithConsumerStopped();
+    } else {
+      refreshCache();
+    }
+  }
+
+  /**
+   * The consumer is stopped while the dataset is parsed, so that changes it reads are not overwritten by
+   * the older export, and comes back whether or not the refresh worked.
+   *
+   * <p>A restart that fails is not swallowed. Returning normally tells the refresher the cache was
+   * rebuilt, which keeps the recorded dataset version and stops the checks from retrying, so a transient
+   * Kafka failure would leave the changelog dead until the next export. When the refresh failed too, that
+   * exception is the one that carries and the restart failure rides along as suppressed.
+   */
+  private void refreshWithConsumerStopped() {
     RuntimeException refreshFailure = null;
     try {
-      changelogConsumerController.stop();
       stopPlaceChangelog.unregisterStopPlaceChangelogListener(handler);
-      Instant publicationTime = stopPlaceRepositoryLoader.refreshCache();
-      changelogUpdateTimestampRepository.setTimestamp(publicationTime);
-      antuPublicationTimeRecordFilterStrategy.setPublicationTime(
-        publicationTime
-      );
+      changelogConsumerController.stop();
+      refreshCache();
     } catch (RuntimeException e) {
       refreshFailure = e;
     }
 
     try {
-      stopPlaceChangelog.registerStopPlaceChangelogListener(handler);
-      changelogConsumerController.start();
+      startConsumerIfLeader();
     } catch (RuntimeException e) {
       if (refreshFailure == null) {
         throw e;
@@ -104,5 +132,29 @@ public class ChangelogStopPlaceRepositoryUpdater
     if (refreshFailure != null) {
       throw refreshFailure;
     }
+  }
+
+  /**
+   * The only place the consumer is started, and it checks the lease itself rather than trusting the caller.
+   * A refresh takes long enough to lose the lease while it runs, and taking over and standing down are
+   * delivered on separate threads, so neither caller can promise leadership still holds by the time this
+   * runs. Whichever of this and {@link #standDown()} runs last decides, and both agree once the lease has
+   * moved.
+   */
+  private void startConsumerIfLeader() {
+    if (!leaderElection.isLeader()) {
+      LOGGER.info(
+        "Not the leader any more, leaving the stop place changelog consumer stopped"
+      );
+      return;
+    }
+    stopPlaceChangelog.registerStopPlaceChangelogListener(handler);
+    changelogConsumerController.start();
+  }
+
+  private void refreshCache() {
+    Instant publicationTime = stopPlaceRepositoryLoader.refreshCache();
+    changelogUpdateTimestampRepository.setTimestamp(publicationTime);
+    antuPublicationTimeRecordFilterStrategy.setPublicationTime(publicationTime);
   }
 }

--- a/src/main/java/no/entur/antu/stop/changelog/StopPlaceRepositoryUpdater.java
+++ b/src/main/java/no/entur/antu/stop/changelog/StopPlaceRepositoryUpdater.java
@@ -10,6 +10,11 @@ public interface StopPlaceRepositoryUpdater {
   default void init() {}
 
   /**
+   * Stop whatever {@link #init()} started, because this pod is no longer the leader.
+   */
+  default void standDown() {}
+
+  /**
    * Create the stop place repository if it is empty, otherwise update the stop place repository.
    */
   void createOrUpdate();

--- a/src/test/java/no/entur/antu/leader/RedisLeaseLeaderElectionTest.java
+++ b/src/test/java/no/entur/antu/leader/RedisLeaseLeaderElectionTest.java
@@ -99,6 +99,32 @@ class RedisLeaseLeaderElectionTest extends EmbeddedRedisTestBase {
       .until(() -> events.size() == 1);
   }
 
+  /**
+   * Whatever the leader started has to be told to stop, or it keeps running alongside the new leader's.
+   */
+  @Test
+  void standingDownIsAnnouncedOnce() {
+    RedisLeaseLeaderElection pod = pod();
+    pod.heartbeat();
+    await().atMost(Duration.ofSeconds(5)).until(() -> events.size() == 1);
+
+    // Another pod takes the lease, so this one cannot simply reacquire it and become leader again.
+    redissonClient.getBucket("ANTU_LEADER").delete();
+    pod().heartbeat();
+    await().atMost(Duration.ofSeconds(5)).until(() -> events.size() == 2);
+
+    pod.heartbeat();
+    pod.heartbeat();
+
+    assertFalse(pod.isLeader());
+    await().atMost(Duration.ofSeconds(5)).until(() -> events.size() == 3);
+    assertTrue(events.get(2) instanceof LeadershipLostEvent);
+    await()
+      .during(Duration.ofMillis(300))
+      .atMost(Duration.ofSeconds(5))
+      .until(() -> events.size() == 3);
+  }
+
   @Test
   void aHeartbeatExtendsTheLease() {
     RedisLeaseLeaderElection pod = pod();

--- a/src/test/java/no/entur/antu/pipeline/StopPlaceCacheRefresherTest.java
+++ b/src/test/java/no/entur/antu/pipeline/StopPlaceCacheRefresherTest.java
@@ -15,6 +15,7 @@ import no.entur.antu.job.AntuJob;
 import no.entur.antu.job.JobQueue;
 import no.entur.antu.leader.LeaderElection;
 import no.entur.antu.leader.LeadershipGrantedEvent;
+import no.entur.antu.leader.LeadershipLostEvent;
 import no.entur.antu.stop.StopPlaceDatasetVersionRepository;
 import no.entur.antu.stop.StopPlaceRepositoryLoader;
 import no.entur.antu.stop.changelog.StopPlaceRepositoryUpdater;
@@ -212,6 +213,27 @@ class StopPlaceCacheRefresherTest {
     );
 
     verify(datasetVersionRepository, never()).set(anyString());
+  }
+
+  /**
+   * The changelog consumer is the leader's, so losing the lease has to take it down.
+   */
+  @Test
+  void losingLeadershipStandsTheUpdaterDown() {
+    refresher.onLeadershipLost(new LeadershipLostEvent());
+
+    verify(stopPlaceRepositoryUpdater).standDown();
+  }
+
+  @Test
+  void aStandDownThatFailsIsContained() {
+    doThrow(new IllegalStateException("kafka is down"))
+      .when(stopPlaceRepositoryUpdater)
+      .standDown();
+
+    assertDoesNotThrow(() ->
+      refresher.onLeadershipLost(new LeadershipLostEvent())
+    );
   }
 
   private void leaderSees(String inBucket, String recorded) {

--- a/src/test/java/no/entur/antu/stop/changelog/ChangelogStopPlaceRepositoryUpdaterTest.java
+++ b/src/test/java/no/entur/antu/stop/changelog/ChangelogStopPlaceRepositoryUpdaterTest.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import no.entur.antu.leader.LeaderElection;
 import no.entur.antu.stop.StopPlaceRepositoryLoader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ class ChangelogStopPlaceRepositoryUpdaterTest {
   private ChangelogConsumerController changelogConsumerController;
   private StopPlaceChangelog stopPlaceChangelog;
   private AntuStopPlaceChangeLogListener handler;
+  private LeaderElection leaderElection;
   private ChangelogStopPlaceRepositoryUpdater updater;
 
   @BeforeEach
@@ -36,6 +38,8 @@ class ChangelogStopPlaceRepositoryUpdaterTest {
     changelogConsumerController = mock(ChangelogConsumerController.class);
     stopPlaceChangelog = mock(StopPlaceChangelog.class);
     handler = mock(AntuStopPlaceChangeLogListener.class);
+    leaderElection = mock(LeaderElection.class);
+    when(leaderElection.isLeader()).thenReturn(true);
     updater =
       new ChangelogStopPlaceRepositoryUpdater(
         stopPlaceRepositoryLoader,
@@ -43,7 +47,8 @@ class ChangelogStopPlaceRepositoryUpdaterTest {
         mock(RedisChangelogUpdateTimestampRepository.class),
         changelogConsumerController,
         stopPlaceChangelog,
-        handler
+        handler,
+        leaderElection
       );
   }
 
@@ -137,5 +142,79 @@ class ChangelogStopPlaceRepositoryUpdaterTest {
 
     assertEquals("bad export", thrown.getMessage());
     assertEquals("kafka is down", thrown.getSuppressed()[0].getMessage());
+  }
+
+  /**
+   * The consumer belongs to the leader, and refresh jobs run on an arbitrary pod. A pod without a
+   * consumer must not come out of a refresh with one: nothing would stop it again, and it would replay
+   * the whole retained topic on top of the leader's.
+   */
+  @Test
+  void aRefreshOffTheLeaderLeavesTheConsumerAlone() {
+    when(leaderElection.isLeader()).thenReturn(false);
+    when(stopPlaceRepositoryLoader.refreshCache()).thenReturn(Instant.now());
+
+    updater.createOrUpdate();
+
+    verify(stopPlaceRepositoryLoader).refreshCache();
+    verify(changelogConsumerController, never()).start();
+    verify(changelogConsumerController, never()).stop();
+    verify(stopPlaceChangelog, never())
+      .registerStopPlaceChangelogListener(handler);
+  }
+
+  /**
+   * A refresh takes long enough for the lease to move. Restarting on the strength of the check made
+   * before the parse would leave an ex-leader consuming alongside the new one.
+   */
+  @Test
+  void leadershipLostDuringARefreshLeavesTheConsumerStopped() {
+    when(leaderElection.isLeader()).thenReturn(true, false);
+    when(stopPlaceRepositoryLoader.refreshCache()).thenReturn(Instant.now());
+
+    updater.createOrUpdate();
+
+    verify(stopPlaceRepositoryLoader).refreshCache();
+    verify(changelogConsumerController).stop();
+    verify(changelogConsumerController, never()).start();
+  }
+
+  @Test
+  void standingDownStopsTheConsumer() {
+    updater.standDown();
+
+    verify(changelogConsumerController).stop();
+    verify(stopPlaceChangelog).unregisterStopPlaceChangelogListener(handler);
+    verify(changelogConsumerController, never()).start();
+  }
+
+  /**
+   * The listener is what puts records into the shared cache, so a Kafka shutdown that fails must not leave
+   * it registered while the new leader takes over.
+   */
+  @Test
+  void standingDownUnregistersEvenIfTheConsumerCannotBeStopped() {
+    doThrow(new IllegalStateException("kafka is down"))
+      .when(changelogConsumerController)
+      .stop();
+
+    assertThrows(IllegalStateException.class, () -> updater.standDown());
+
+    verify(stopPlaceChangelog).unregisterStopPlaceChangelogListener(handler);
+  }
+
+  /**
+   * Taking over and standing down arrive on separate threads, so init() cannot assume the lease still
+   * holds by the time it runs.
+   */
+  @Test
+  void initialisingAfterTheLeaseHasMovedDoesNotStartTheConsumer() {
+    when(leaderElection.isLeader()).thenReturn(false);
+
+    updater.init();
+
+    verify(changelogConsumerController, never()).start();
+    verify(stopPlaceChangelog, never())
+      .registerStopPlaceChangelogListener(handler);
   }
 }


### PR DESCRIPTION
Refresh jobs run on whichever pod picks them off the queue, and createOrUpdate() ended with changelogConsumerController.start() whatever pod that was. A refresh landing off the leader left that pod with a consumer nothing stops again, replaying the whole retained topic on top of the leader's. Seen in dev on 2026-08-24: the leader queued the refresh, another pod ran it and started seeking partitions right after.

A non-leader now rebuilds the cache and leaves the consumer alone. Not keyed on isRunning(): a leader whose consumer died from a failed start also reads as not running, and skipping the restart there would leave the changelog dead with the refresh reporting success.

Both callers that touch the consumer are now on the leader, so the monitor between init() and createOrUpdate() is enough and the cross-pod case is gone.